### PR TITLE
remove redundant clone that caused memory leak

### DIFF
--- a/src/fields2cover/types/Point.cpp
+++ b/src/fields2cover/types/Point.cpp
@@ -61,7 +61,7 @@ Point Point::operator*(double b) const {
   return Point(data->getX() * b, data->getY() * b, data->getZ() * b);
 }
 
-Point Point::clone() const {return Point(data->clone());}
+Point Point::clone() const {return Point(data);}
 double Point::getX() const {return data->getX();}
 double Point::getY() const {return data->getY();}
 double Point::getZ() const {return data->getZ();}


### PR DESCRIPTION

We found a memory leak in `Point`, there is a redundant clone that does not cleaned up. The fix is simple, just remove the extra clone.
Below is a screen shot of the valgrind report on the unit test. 

![image](https://user-images.githubusercontent.com/3401258/190058890-c4c14d07-8aa8-4c66-bf6d-527a610145dd.png)
