### PR TITLE
Add support for the ROS build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,14 +102,14 @@ foreach(p LIB BIN INCLUDE CMAKE)
   endif()
 endforeach()
 
-file(GLOB_RECURSE fields2cover_src 
+file(GLOB_RECURSE fields2cover_src
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*/*/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*/*/*/*.cpp"
    )
 
-list(REMOVE_ITEM fields2cover_src 
+list(REMOVE_ITEM fields2cover_src
     "${CMAKE_CURRENT_SOURCE_DIR}/.*"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/.*"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*/.*"
@@ -119,7 +119,7 @@ list(REMOVE_ITEM fields2cover_src
 
 add_library(Fields2Cover SHARED ${fields2cover_src})
 
-target_compile_features(Fields2Cover PUBLIC cxx_std_17) 
+target_compile_features(Fields2Cover PUBLIC cxx_std_17)
 
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
@@ -161,11 +161,11 @@ target_include_directories(Fields2Cover PUBLIC
 )
 
 
-target_link_libraries(Fields2Cover 
+target_link_libraries(Fields2Cover
   PUBLIC
     ${GDAL_LIBRARIES}
     -lpthread
-  PRIVATE 
+  PRIVATE
     nlohmann_json::nlohmann_json
     tinyxml2::tinyxml2
     steering_functions
@@ -182,7 +182,7 @@ set_target_properties(Fields2Cover PROPERTIES
   INTERPROCEDURAL_OPTIMIZATION TRUE PUBLIC_HEADER "include/fields2cover.h")
 
 install(TARGETS Fields2Cover
-  EXPORT Fields2Cover-targets 
+  EXPORT Fields2Cover-targets
   LIBRARY DESTINATION ${INSTALL_LIB_DIR}
   ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
   RUNTIME DESTINATION ${INSTALL_BIN_DIR}
@@ -205,6 +205,9 @@ configure_file(cmake/Fields2CoverConfigVersion.cmake.in
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Fields2CoverConfig.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/Fields2CoverConfigVersion.cmake"
         DESTINATION ${INSTALL_CMAKE_DIR}/cmake/fields2cover)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/package.xml
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
 
 export(TARGETS Fields2Cover
   FILE Fields2CoverTargets.cmake)
@@ -237,7 +240,7 @@ include(CPack)
 
 if (BUILD_TUTORIALS)
     add_subdirectory(tutorials)
-endif() 
+endif()
 
 #####################################################
 ######################### swig ######################
@@ -245,7 +248,7 @@ endif()
 
 if (BUILD_PYTHON)
     add_subdirectory(swig)
-endif() 
+endif()
 
 #####################################################
 ######################### test ######################
@@ -269,4 +272,3 @@ endif()  # BUILD_CPP
 if(BUILD_DOC)
   add_subdirectory(docs)
 endif()
-

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+
+<!-- A package.xml in the root of a cmake projects allows it to be built using catkin or colcon (the ROS build system) -->
+
+<package format="2">
+  <name>fields2cover</name>
+  <version>1.2.0</version>
+  <description>
+    Robust and efficient coverage paths for autonomous agricultural vehicles.
+    A modular and extensible Coverage Path Planning library
+  </description>
+
+  <maintainer email="gonzalo.miermunoz@wur.nl">Gonzalo Mier</maintainer>
+  <license>BSD-3</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <depend>eigen</depend>
+  <depend>git</depend>
+  <depend>libgdal-dev</depend>
+  <depend>swig</depend>
+  <depend>tbb</depend>
+  <exec_depend>python3-matplotlib</exec_depend>
+  <exec_depend>python3-tk</exec_depend>
+  <test_depend>gtest</test_depend>
+  <test_depend>lcov</test_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Note that this does not make this library a ROS package. It will still be standalone.

However for people within a ROS ecosystem, this would greatly improve the build experience (and drop a `sudo make install` command).

Can be verified with this dockerfile (which might be added to CI):

```Dockerfile
FROM ros:noetic
RUN mkdir -p /ws/src
WORKDIR /ws
RUN apt-get update -qq && apt-get install -qqy python3-catkin-tools python3-osrf-pycommon git software-properties-common

RUN add-apt-repository -y ppa:ubuntugis/ppa && apt-get update -qq

RUN git clone https://github.com/nobleo/Fields2Cover src/fields2cover --branch compile-with-ros
RUN git clone https://github.com/Fields2Cover/fields2cover_ros src/fields2cover_ros
RUN rosdep install -r --ignore-src -y --from-paths .

RUN bash -c 'source /opt/ros/*/setup.bash && catkin build'
RUN bash -c 'source /opt/ros/*/setup.bash && catkin run_tests'
```