### PR TITLE
Fix: Correct order generated if bulk size is bigger than 6

### DIFF
--- a/src/fields2cover/route_planning/spiral_order.cpp
+++ b/src/fields2cover/route_planning/spiral_order.cpp
@@ -26,7 +26,7 @@ void SpiralOrder::sortSwaths(F2CSwaths& swaths) const {
 }
 
 void SpiralOrder::spiral(F2CSwaths& swaths, size_t offset, size_t size) const {
-  for (size_t j = offset % 2 ? 0 : 1; j <= (size + 1) / 2; j += 2) {
+  for (size_t j = (offset + 1) % 2; j < size; j += 2) {
     std::rotate(swaths.begin() + offset + j,
                 swaths.begin() + offset + size - 1,
                 swaths.begin() + offset + size);

--- a/tests/cpp/route_planning/spiral_order_test.cpp
+++ b/tests/cpp/route_planning/spiral_order_test.cpp
@@ -145,3 +145,35 @@ TEST(fields2cover_route_spiral, genSortedSwaths_default_cstr) {
   EXPECT_EQ(swaths[8].getWidth(), 9);
   EXPECT_EQ(swaths[9].getWidth(), 10);
 }
+
+
+TEST(fields2cover_route_spiral, genSortedSwaths_bigger_than_8_bulk) {
+  const int size = 10;
+  F2CSwaths swaths;
+  for (int i = 1; i <= size; ++i) {
+    swaths.emplace_back(F2CLineString({F2CPoint(0, i), F2CPoint(1, i)}), i, i);
+  }
+  f2c::rp::SpiralOrder swath_sorter;
+  swath_sorter.setSpiralSize(size);
+  swaths = swath_sorter.genSortedSwaths(swaths);
+
+  EXPECT_EQ(swaths[0].getWidth(), 1);
+  EXPECT_EQ(swaths[1].getWidth(), 10);
+  EXPECT_EQ(swaths[2].getWidth(), 2);
+  EXPECT_EQ(swaths[3].getWidth(), 9);
+  EXPECT_EQ(swaths[4].getWidth(), 3);
+  EXPECT_EQ(swaths[5].getWidth(), 8);
+  EXPECT_EQ(swaths[6].getWidth(), 4);
+  EXPECT_EQ(swaths[7].getWidth(), 7);
+  EXPECT_EQ(swaths[8].getWidth(), 5);
+  EXPECT_EQ(swaths[9].getWidth(), 6);
+}
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
The issue https://github.com/Fields2Cover/Fields2Cover/issues/61 is solved and the correct order is generated.

![field_circular](https://user-images.githubusercontent.com/3874494/223157354-98dd4305-3ee2-40c5-a679-3c6d43c21988.png)
