### PR TITLE
Add option for overlapping swaths

### DIFF
--- a/include/fields2cover/swath_generator/swath_generator_base.h
+++ b/include/fields2cover/swath_generator/swath_generator_base.h
@@ -22,6 +22,9 @@ namespace f2c::sg {
 template <typename T>
 class SwathGeneratorBase {
  public:
+   bool allow_overlap {false};
+
+ public:
   virtual F2CSwaths generateBestSwaths(f2c::obj::SGObjective& obj,
       double op_width, const F2CCell& poly) = 0;
 
@@ -33,6 +36,8 @@ class SwathGeneratorBase {
 
   virtual F2CSwathsByCells generateSwaths(double angle,
       double op_width, const F2CCells& polys);
+
+  void setAllowOverlap(bool value) {allow_overlap = value;}
 };
 
 }  // namespace f2c::sg

--- a/include/fields2cover/swath_generator/swath_generator_base_impl.hpp
+++ b/include/fields2cover/swath_generator/swath_generator_base_impl.hpp
@@ -49,7 +49,7 @@ F2CSwaths SwathGeneratorBase<T>::generateSwaths(double angle,
     swaths.append(path, poly, op_width);
   }
 
-  if (allow_overlap && field_width - ((n_swaths - 1) * op_width) > 1e-6) {
+  if (allow_overlap && field_width - ((n_swaths - 1) * op_width) < op_width / 2) {
     auto path = F2CPoint(0.0, 0.0).rotateFromPoint(-angle,
                                                     seed_curve + F2CPoint(field_width - op_width / 2, 0.0));
     swaths.append(path, poly, op_width);

--- a/include/fields2cover/swath_generator/swath_generator_base_impl.hpp
+++ b/include/fields2cover/swath_generator/swath_generator_base_impl.hpp
@@ -48,6 +48,12 @@ F2CSwaths SwathGeneratorBase<T>::generateSwaths(double angle,
         seed_curve + F2CPoint(op_width, 0.0) * (i + 0.5));
     swaths.append(path, poly, op_width);
   }
+
+  if (allow_overlap && field_width - ((n_swaths - 1) * op_width) > 1e-6) {
+    auto path = F2CPoint(0.0, 0.0).rotateFromPoint(-angle,
+                                                    seed_curve + F2CPoint(field_width - op_width / 2, 0.0));
+    swaths.append(path, poly, op_width);
+  }
   return swaths;
 }
 


### PR DESCRIPTION
Closes #70 

This adds an option to have overlapping swaths in order to cover a complete field. Example code:

```python
import fields2cover as f2c
import numpy as np

robot = f2c.Robot(11.0, 11.0)
robot.setMinRadius(0)
robot.start_point = f2c.optional_Point(f2c.Point(3.0, 4.0))
robot.linear_curv_change = 0

field_border = f2c.LinearRing()
field_border.addPoint(0, 0)
field_border.addPoint(0, 47)
field_border.addPoint(47, 47)
field_border.addPoint(47, 0)
field_border.addPoint(field_border.StartPoint())

field_cell = f2c.Cell()
field_cell.addRing(field_border)

field = f2c.Field()
field.field.addGeometry(field_cell)

# Generate no headland
const_hl = f2c.HG_Const_gen()
no_hl = const_hl.generateHeadlands(field.field, 0)
bf = f2c.SG_BruteForce()
bf.setAllowOverlap(True)

swaths = bf.generateSwaths(np.pi, robot.op_width, no_hl.getGeometry(0))

sorter = f2c.RP_Boustrophedon()
swaths = sorter.genSortedSwaths(swaths)

print(swaths)

f2c.Visualizer.figure(100)
f2c.Visualizer.plot(swaths)
f2c.Visualizer.show()
```

With `bf.setAllowOverlap(False)` (default behavior):

![default](https://github.com/Fields2Cover/Fields2Cover/assets/78429257/7552163a-0aeb-44b1-bdb5-3c6aadafafe5)

With `bf.setAllowOverlap(True)`:

![overlap](https://github.com/Fields2Cover/Fields2Cover/assets/78429257/34bed8eb-e90f-48d2-94bd-4761b7e4e0fb)
