### PR TITLE
fix pack expansion when compiled with clang

### DIFF
--- a/include/fields2cover/types/Cell.h
+++ b/include/fields2cover/types/Cell.h
@@ -23,7 +23,8 @@ namespace f2c::types {
 template < typename... Args >
 inline std::string sstr(Args &&... args) {
   std::ostringstream sstr;
-  (sstr << std::dec << ... << args);
+  sstr << std::dec;
+  (sstr <<  ...  << args);
   return sstr.str();
 }
 

--- a/tests/cpp/types/Cell_test.cpp
+++ b/tests/cpp/types/Cell_test.cpp
@@ -173,3 +173,16 @@ TEST(fields2cover_types_cell, Buffer) {
   EXPECT_NEAR(line_buffer.getArea(), 2 * 2 * 4 + 4 * 4 * M_PI, 1e-1);
 }
 
+TEST(fields2cover_types_sstr, NumberStringConcat) {
+  auto result = f2c::types::sstr("word", 10, "another word", 20, 30);
+  EXPECT_EQ(result, "word10another word2030");
+
+  std::stringstream ss;
+  ss << std::hex << 10 << f2c::types::sstr(10, 0xA, "10", "a");
+  result = ss.str();
+  EXPECT_EQ(result, "a101010a");
+
+  result = f2c::types::sstr(std::hex, 10, 10, std::dec, 10, 10);
+  EXPECT_EQ(result, "aa1010");
+}
+


### PR DESCRIPTION
fixes compilation with clang-15 (using c++20)

error was: (#79)

```
In file included from Fields2Cover/src/fields2cover/objectives/swath_length.cpp:7:
In file included fromFields2Cover/include/fields2cover/objectives/swath_length.h:12:
In file included from Fields2Cover/include/fields2cover/types.h:20:
Fields2Cover/include/fields2cover/types/Cell.h:26:9: error: expression not permitted as operand of fold expression
  (sstr << std::dec << ... << args);
   ~~~~~^~~~~~~~~~~
   (            )
2 warnings and 1 error generated.
```