### PR TITLE
Fail silently for cartesian systems

### DIFF
--- a/include/fields2cover/utils/parser.h
+++ b/include/fields2cover/utils/parser.h
@@ -24,7 +24,7 @@ class Parser {
     /// @param fields Set of fields saved on _file.
     static void importGml(const std::string& file, F2CFields& fields);
 
-    static F2CField importFieldGml(const std::string& file);
+    static F2CField importFieldGml(const std::string& file, bool fail_silently = false);
 
     /// Function to import file with Json extension.
     /// @param file Path to the imported file.

--- a/include/fields2cover/utils/transformation.h
+++ b/include/fields2cover/utils/transformation.h
@@ -61,7 +61,7 @@ class Transform {
   static F2CPoint getRefPointInGPS(const F2CField& field);
 
   static std::unique_ptr<OGRSpatialReference, void(*)(OGRSpatialReference*)>
-        createSptRef(const std::string& coord_sys);
+        createSptRef(const std::string& coord_sys, bool fail_silently = false);
 
   static std::unique_ptr<OGRCoordinateTransformation,
     void(*)(OGRCoordinateTransformation*)> createCoordTransf(

--- a/src/fields2cover/utils/parser.cpp
+++ b/src/fields2cover/utils/parser.cpp
@@ -18,7 +18,7 @@ void Parser::importGml(const std::string& file, F2CFields& fields) {
   fields.emplace_back(importFieldGml(file));
 }
 
-F2CField Parser::importFieldGml(const std::string& file) {
+F2CField Parser::importFieldGml(const std::string& file, bool coord_frame_fail_silently) {
   // Tinyxml2 depends on locale when parsing files. It may expect float numbers
   // as "1,5" instead of "1.5", which is parsed as "1". The next line solves
   // the issue.
@@ -66,7 +66,7 @@ F2CField Parser::importFieldGml(const std::string& file) {
   findAndReplaceAll(p_coords, ";", " ");
   p_coords = "POLYGON ((" + p_coords + "))";
   OGRGeometry* new_geom{};
-  auto spt_ref = Transform::createSptRef(coord_sys);
+  auto spt_ref = Transform::createSptRef(coord_sys, coord_frame_fail_silently);
   OGRGeometryFactory::createFromWkt(p_coords.c_str(), spt_ref.get(), &new_geom);
 
   F2CField field(F2CCells(new_geom), id);

--- a/src/fields2cover/utils/transformation.cpp
+++ b/src/fields2cover/utils/transformation.cpp
@@ -177,12 +177,12 @@ F2CPoint Transform::getRefPointInGPS(const F2CField& field) {
 }
 
 std::unique_ptr<OGRSpatialReference, void(*)(OGRSpatialReference*)>
-      Transform::createSptRef(const std::string& coord_sys) {
+      Transform::createSptRef(const std::string& coord_sys, bool fail_silently) {
   auto spt_ref =
     std::unique_ptr<OGRSpatialReference, void(*)(OGRSpatialReference*)>(
       new OGRSpatialReference(), [](OGRSpatialReference* ref) {
       OGRSpatialReference::DestroySpatialReference(ref);});
-  if (coord_sys.empty()) {
+  if (coord_sys.empty() && !fail_silently) {
     throw std::invalid_argument("Coordinate system empty");
   } else if (F2CField::isCoordSystemEPSG(coord_sys)) {
     spt_ref->importFromEPSG(F2CField::getEPSGCoordSystem(coord_sys));
@@ -195,7 +195,7 @@ std::unique_ptr<OGRSpatialReference, void(*)(OGRSpatialReference*)>
         " +datum=" + F2CField::getUTMDatum(coord_sys))
       + " +units=m +no_defs ");
     spt_ref->importFromProj4(proj.c_str());
-  } else  {
+  } else if (!fail_silently) {
     throw std::invalid_argument("Coordinate system not recognized");
   }
   if (GDALVersionInfo("VERSION_NUM")[0] == '3') {


### PR DESCRIPTION
Currently the parser has very strict interpretations of `srsName`. This adds a more relaxed option for parsing files that have empty or non-GPS frames (e.g. `map`). By default, nothing changes, you have to explicitly enable this flag to allow for silent failing of coord parsing with `createSptRef` messing with references. 