### PR TITLE
swath and swaths transform with reference points

### DIFF
--- a/include/fields2cover/types/Swath.h
+++ b/include/fields2cover/types/Swath.h
@@ -91,6 +91,9 @@ struct Swath {
   /// less than pi
   void targetOppositeDirAs(const Swath& s);
 
+  /// Moves swath data by a reference point
+  void moveTo(const Point& ref_pt);
+
  private:
   int id_ {0};  // Id of the swath
   LineString path_;

--- a/include/fields2cover/types/Swaths.h
+++ b/include/fields2cover/types/Swaths.h
@@ -63,6 +63,7 @@ struct Swaths {
       double width = 0, SwathType type = SwathType::MAINLAND);
   void sort();
   void reverseDirOddSwaths();
+  void moveTo(const Point& ref_pt);
 
   Swaths clone() const;
 

--- a/include/fields2cover/utils/transformation.h
+++ b/include/fields2cover/utils/transformation.h
@@ -26,6 +26,10 @@ class Transform {
 
   static F2CPath transformPathWithFieldRef(const F2CPath& path,
       const F2CField& field, const std::string& coord_sys_to);
+  static F2CSwath transformSwathWithFieldRef(const F2CSwath& swath,
+      const F2CField& field, const std::string& coord_sys_to);
+  static F2CSwaths transformSwathsWithFieldRef(const F2CSwaths& swaths,
+      const F2CField& field, const std::string& coord_sys_to);
 
 
   static void transform(F2CField& field, const std::string& coord_sys_to);

--- a/src/fields2cover/types/Swath.cpp
+++ b/src/fields2cover/types/Swath.cpp
@@ -193,6 +193,10 @@ void Swath::setType(SwathType type) {
   this->type_ = type;
 }
 
+void Swath::moveTo(const Point& ref_pt) {
+  for (auto&& s : this->path_) {
+    s = s + ref_pt;
+  }
+}
 
 }  // namespace f2c::types
-

--- a/src/fields2cover/types/Swaths.cpp
+++ b/src/fields2cover/types/Swaths.cpp
@@ -141,6 +141,11 @@ Swaths Swaths::clone() const {
   return new_s;
 }
 
+void Swaths::moveTo(const Point& ref_pt) {
+  for (auto&& s : data) {
+    s.moveTo(ref_pt);
+  }
+}
 
 
 }  // namespace f2c::types

--- a/src/fields2cover/utils/transformation.cpp
+++ b/src/fields2cover/utils/transformation.cpp
@@ -43,6 +43,21 @@ F2CPath Transform::transformPathWithFieldRef(const F2CPath& path,
   return new_path;
 }
 
+F2CSwath Transform::transformSwathWithFieldRef(const F2CSwath& swath,
+      const F2CField& field, const std::string& coord_sys_to) {
+  return F2CSwath(transform(swath.getPath(), field.getRefPoint(), field.getCRS(), coord_sys_to),
+                   swath.getWidth(), swath.getId());
+}
+
+F2CSwaths Transform::transformSwathsWithFieldRef(const F2CSwaths& swaths,
+      const F2CField& field, const std::string& coord_sys_to) {
+  F2CSwaths new_swaths;
+  for (auto&& swath : swaths) {
+    new_swaths.emplace_back(
+        transformSwathWithFieldRef(swath, field, coord_sys_to));
+  }
+  return new_swaths;
+}
 
 F2CStrip Transform::transformStrip(const F2CStrip& strip,
       const std::string& coord_sys_from, const std::string& coord_sys_to) {
@@ -87,7 +102,6 @@ F2CPath Transform::transformPath(const F2CPath& path,
   }
   return new_path;
 }
-
 
 void Transform::transformToUTM(F2CField& field, bool is_etrs89_opt) {
   std::string field_crs = field.getCRS();
@@ -162,12 +176,12 @@ F2CStrips Transform::transformToPrevCRS(
 
 F2CSwath Transform::transformToPrevCRS(
     const F2CSwath& s, const F2CField& field) {
-  return transformSwath(s, field.getCRS(), field.getPrevCRS());
+  return transformSwathWithFieldRef(s, field, field.getPrevCRS());
 }
 
 F2CSwaths Transform::transformToPrevCRS(
     const F2CSwaths& s, const F2CField& field) {
-  return transformSwaths(s, field.getCRS(), field.getPrevCRS());
+  return transformSwathsWithFieldRef(s, field, field.getPrevCRS());
 }
 
 F2CPoint Transform::getRefPointInGPS(const F2CField& field) {

--- a/tests/cpp/types/Swaths_test.cpp
+++ b/tests/cpp/types/Swaths_test.cpp
@@ -101,5 +101,22 @@ TEST(fields2cover_types_swaths, push_back) {
 }
 
 
+TEST(fields2cover_types_swaths, move_to) {
+  const int n = 10;
+  F2CSwaths swaths;
+  for (int i = 1; i <= n; ++i) {
+    F2CSwath swath {F2CLineString({F2CPoint(i, i), F2CPoint(i, i + 1)}), 1.0*i, i};
+    swaths.push_back(swath);
+  }
+
+  F2CSwaths init_swaths = swaths.clone();
+  F2CPoint pt(1.0, 2.0);
+  swaths.moveTo(pt);
+
+  for (int i = 1; i < n; ++i) {
+    EXPECT_EQ(swaths.at(i).startPoint(), init_swaths.at(i).startPoint() + pt);
+  }
+}
+
 
 

--- a/tests/cpp/utils/transform_test.cpp
+++ b/tests/cpp/utils/transform_test.cpp
@@ -156,7 +156,8 @@ TEST(fields2cover_utils_transformer, convert_types) {
   EXPECT_NEAR(returned_path3.states[0].point.getX(), 6.062131843297665, 1e-3);
   EXPECT_NEAR(returned_path3.states[0].point.getY(), 51.51238564279176, 1e-3);
 
-
-
-
+  auto returned_swaths =
+    f2c::Transform::transformSwathsWithFieldRef(moved_swaths, field, "EPSG:4326");
+  EXPECT_NEAR(returned_path2.states[0].point.getX(), 6.062131843297665, 1e-3);
+  EXPECT_NEAR(returned_path2.states[0].point.getY(), 51.51238564279176, 1e-3);
 }


### PR DESCRIPTION
Does the same as the `path` for the swath data, I believe. I use the other transform function you have instead of manually typing it all out like you do in `transformPathWithFieldRef`. I believe these are identical operations however. 

I also added some coord reference `moveTo` to swaths like are in `path` for the non-GPS case when I need to add a reference point back to some data