### PR TITLE
add redirect flag

### DIFF
--- a/include/fields2cover/route_planning/route_planner_base.h
+++ b/include/fields2cover/route_planning/route_planner_base.h
@@ -32,8 +32,8 @@ class RoutePlannerBase {
   /// @param d_tol Tolerance distance to consider if two points are the same.
   /// @return Route that covers all the swaths
   virtual F2CRoute genRoute(
-      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells, bool redirect_swaths = true,
-      bool show_log = false, double d_tol = 1e-4);
+      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells,
+      bool show_log = false, double d_tol = 1e-4, bool redirect_swaths = true);
 
   /// Set the start and the end of the route.
   void setStartAndEndPoint(const F2CPoint& p);
@@ -56,9 +56,9 @@ class RoutePlannerBase {
   ///          between two nodes.
   /// @param d_tol Tolerance distance to consider if two points are the same.
   virtual F2CGraph2D createCoverageGraph(
-      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells, bool redirect_swaths,
+      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells,
       F2CGraph2D& shortest_graph,
-      double d_tol) const;
+      double d_tol, bool redirect_swaths = true) const;
 
 
  protected:

--- a/include/fields2cover/route_planning/route_planner_base.h
+++ b/include/fields2cover/route_planning/route_planner_base.h
@@ -32,7 +32,7 @@ class RoutePlannerBase {
   /// @param d_tol Tolerance distance to consider if two points are the same.
   /// @return Route that covers all the swaths
   virtual F2CRoute genRoute(
-      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells,
+      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells, bool redirect_swaths = true,
       bool show_log = false, double d_tol = 1e-4);
 
   /// Set the start and the end of the route.
@@ -56,7 +56,7 @@ class RoutePlannerBase {
   ///          between two nodes.
   /// @param d_tol Tolerance distance to consider if two points are the same.
   virtual F2CGraph2D createCoverageGraph(
-      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells,
+      const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells, bool redirect_swaths,
       F2CGraph2D& shortest_graph,
       double d_tol) const;
 

--- a/src/fields2cover/path_planning/path_planning.cpp
+++ b/src/fields2cover/path_planning/path_planning.cpp
@@ -125,11 +125,22 @@ std::vector<std::pair<F2CPoint, double>> PathPlanning::simplifyConnection(
     }
   }
 
+  if (vp.size() < 2){
+    path.emplace_back(p2, ang2); 
+    return path;
+  }
+
   for (int i = 1; i < vp.size() - 1; ++i) {
     double dist_in  = vp[i].distance(vp[i-1]);
     double dist_out  = vp[i].distance(vp[i+1]);
     double d_in  = min(0.5 * dist_in,  safe_dist);
     double d_out  = min(0.5 * dist_out,  safe_dist);
+    // I haven't checked if this is possible, but
+    // if vp[i] == vp[i-1] or vp == vp[i+1], 
+    // we will get divide by zero error here (dist_in or dist_out).
+    // if (dist_in == 0.0 || dist_out == 0.0){
+    //   std::cout << "dist_in:" << dist_in << "dist_out:" << dist_out << std::endl << std::flush;
+    // }
     F2CPoint p_in =  (vp[i-1] - vp[i]) * (d_in  / dist_in)  + vp[i];
     F2CPoint p_out = (vp[i+1] - vp[i]) * (d_out / dist_out) + vp[i];
     if (p_in.distance(path.back().first) > 3.0 * safe_dist &&

--- a/src/fields2cover/path_planning/path_planning.cpp
+++ b/src/fields2cover/path_planning/path_planning.cpp
@@ -111,11 +111,6 @@ std::vector<std::pair<F2CPoint, double>> PathPlanning::simplifyConnection(
   std::vector<std::pair<F2CPoint, double>> path;
   path.emplace_back(p1, ang1);
 
-  if (p1.distance(p2) < 6.0 * safe_dist || mp.size() <2) {
-    path.emplace_back(p2, ang2);
-    return path;
-  }
-
   std::vector<F2CPoint> vp;
   for (int i = 1; i < mp.size() - 1; ++i) {
     double ang_in  = (mp[i] - mp[i-1]).getAngleFromPoint();
@@ -125,8 +120,8 @@ std::vector<std::pair<F2CPoint, double>> PathPlanning::simplifyConnection(
     }
   }
 
-  if (vp.size() < 2){
-    path.emplace_back(p2, ang2); 
+  if (p1.distance(p2) < 6.0 * safe_dist || vp.size() <2) {
+    path.emplace_back(p2, ang2);
     return path;
   }
 
@@ -137,8 +132,9 @@ std::vector<std::pair<F2CPoint, double>> PathPlanning::simplifyConnection(
     double d_out  = min(0.5 * dist_out,  safe_dist);
     // I haven't checked if this is possible, but
     // if vp[i] == vp[i-1] or vp == vp[i+1], 
-    // we will get divide by zero error here (dist_in or dist_out).
+    // we will get divide by zero error here from dist_in/dist_out.
     // if (dist_in == 0.0 || dist_out == 0.0){
+    //   do something or clean up vp to not have two duplicate points in a row
     //   std::cout << "dist_in:" << dist_in << "dist_out:" << dist_out << std::endl << std::flush;
     // }
     F2CPoint p_in =  (vp[i-1] - vp[i]) * (d_in  / dist_in)  + vp[i];

--- a/src/fields2cover/route_planning/route_planner_base.cpp
+++ b/src/fields2cover/route_planning/route_planner_base.cpp
@@ -19,12 +19,12 @@ namespace f2c::rp {
 namespace ortools = operations_research;
 
 F2CRoute RoutePlannerBase::genRoute(
-    const F2CCells& cells, const F2CSwathsByCells& swaths,
+    const F2CCells& cells, const F2CSwathsByCells& swaths, bool redirect_swaths,
     bool show_log, double d_tol) {
   F2CGraph2D shortest_graph = createShortestGraph(cells, swaths, d_tol);
 
   F2CGraph2D cov_graph = createCoverageGraph(
-      cells, swaths, shortest_graph, d_tol);
+      cells, swaths, redirect_swaths, shortest_graph, d_tol);
 
   std::vector<int64_t> v_route = computeBestRoute(cov_graph, show_log);
   return transformSolutionToRoute(
@@ -87,7 +87,7 @@ F2CGraph2D RoutePlannerBase::createShortestGraph(
 
 
 F2CGraph2D RoutePlannerBase::createCoverageGraph(
-    const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells,
+    const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells, bool redirect_swaths,
     F2CGraph2D& shortest_graph,
     double d_tol) const {
   F2CGraph2D g;
@@ -107,10 +107,12 @@ F2CGraph2D RoutePlannerBase::createCoverageGraph(
         for (const auto& s2 : swaths2) {
           auto s2_s = s2.startPoint();
           auto s2_e = s2.endPoint();
-          g.addEdge(s1_s, s2_s, shortest_graph);
+          if (redirect_swaths) {
+            g.addEdge(s1_s, s2_s, shortest_graph);
+            g.addEdge(s1_e, s2_e, shortest_graph);
+          }
           g.addEdge(s1_s, s2_e, shortest_graph);
           g.addEdge(s1_e, s2_s, shortest_graph);
-          g.addEdge(s1_e, s2_e, shortest_graph);
         }
       }
     }

--- a/src/fields2cover/route_planning/route_planner_base.cpp
+++ b/src/fields2cover/route_planning/route_planner_base.cpp
@@ -97,8 +97,7 @@ F2CGraph2D RoutePlannerBase::createCoverageGraph(
       if (redirect_swaths) {
         g.addEdge(s.startPoint(), mid_p, 0);
         g.addEdge(s.endPoint(), mid_p, 0);
-      }
-      else{
+      } else {
         g.addDirectedEdge(s.startPoint(), mid_p, 0);
         g.addDirectedEdge(mid_p, s.endPoint(), 0);
       }
@@ -118,8 +117,7 @@ F2CGraph2D RoutePlannerBase::createCoverageGraph(
             g.addEdge(s1_e, s2_e, shortest_graph);
             g.addEdge(s1_s, s2_e, shortest_graph);
             g.addEdge(s1_e, s2_s, shortest_graph);
-          }
-          else{
+          } else {
             g.addDirectedEdge(s1_e, s2_s, shortest_graph);
           }
         }

--- a/src/fields2cover/route_planning/route_planner_base.cpp
+++ b/src/fields2cover/route_planning/route_planner_base.cpp
@@ -19,12 +19,12 @@ namespace f2c::rp {
 namespace ortools = operations_research;
 
 F2CRoute RoutePlannerBase::genRoute(
-    const F2CCells& cells, const F2CSwathsByCells& swaths, bool redirect_swaths,
-    bool show_log, double d_tol) {
+    const F2CCells& cells, const F2CSwathsByCells& swaths,
+    bool show_log, double d_tol, bool redirect_swaths) {
   F2CGraph2D shortest_graph = createShortestGraph(cells, swaths, d_tol);
 
   F2CGraph2D cov_graph = createCoverageGraph(
-      cells, swaths, redirect_swaths, shortest_graph, d_tol);
+      cells, swaths, shortest_graph, d_tol, redirect_swaths);
 
   std::vector<int64_t> v_route = computeBestRoute(cov_graph, show_log);
   return transformSolutionToRoute(
@@ -87,15 +87,21 @@ F2CGraph2D RoutePlannerBase::createShortestGraph(
 
 
 F2CGraph2D RoutePlannerBase::createCoverageGraph(
-    const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells, bool redirect_swaths,
+    const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells,
     F2CGraph2D& shortest_graph,
-    double d_tol) const {
+    double d_tol, bool redirect_swaths) const {
   F2CGraph2D g;
   for (auto&& swaths : swaths_by_cells) {
     for (auto&& s : swaths) {
       F2CPoint mid_p {(s.startPoint() + s.endPoint()) * 0.5};
-      g.addEdge(s.startPoint(), mid_p, 0);
-      g.addEdge(s.endPoint(), mid_p, 0);
+      if (redirect_swaths) {
+        g.addEdge(s.startPoint(), mid_p, 0);
+        g.addEdge(s.endPoint(), mid_p, 0);
+      }
+      else{
+        g.addDirectedEdge(s.startPoint(), mid_p, 0);
+        g.addDirectedEdge(mid_p, s.endPoint(), 0);
+      }
     }
   }
 
@@ -110,9 +116,12 @@ F2CGraph2D RoutePlannerBase::createCoverageGraph(
           if (redirect_swaths) {
             g.addEdge(s1_s, s2_s, shortest_graph);
             g.addEdge(s1_e, s2_e, shortest_graph);
+            g.addEdge(s1_s, s2_e, shortest_graph);
+            g.addEdge(s1_e, s2_s, shortest_graph);
           }
-          g.addEdge(s1_s, s2_e, shortest_graph);
-          g.addEdge(s1_e, s2_s, shortest_graph);
+          else{
+            g.addDirectedEdge(s1_e, s2_s, shortest_graph);
+          }
         }
       }
     }

--- a/tests/cpp/route_planning/route_planner_base_test.cpp
+++ b/tests/cpp/route_planning/route_planner_base_test.cpp
@@ -89,7 +89,7 @@ TEST(fields2cover_rp_route_plan_base, redirect_flag) {
   
   F2CSwaths old_swaths = swaths.flatten();
   F2CSwaths new_swaths;
-  for (int sbc = 1; sbc < route.getVectorSwaths().size(); ++sbc){
+  for (int sbc = 1; sbc < route.sizeVectorSwaths(); ++sbc){
     new_swaths.append(route.getSwaths(sbc));
   }
 

--- a/tests/cpp/route_planning/route_planner_base_test.cpp
+++ b/tests/cpp/route_planning/route_planner_base_test.cpp
@@ -89,11 +89,13 @@ TEST(fields2cover_rp_route_plan_base, redirect_flag) {
   
   F2CSwaths old_swaths = swaths.flatten();
   F2CSwaths new_swaths;
-  for (int sbc = 1; sbc < route.sizeVectorSwaths(); ++sbc){
+  for (size_t sbc = 0; sbc < route.sizeVectorSwaths(); ++sbc) {
     new_swaths.append(route.getSwaths(sbc));
   }
 
-  for (int s = 1; s < new_swaths.size(); ++s) {
+  EXPECT_EQ(new_swaths.size(), old_swaths.size());
+  
+  for (size_t s = 0; s < new_swaths.size(); ++s) {
     F2CSwath old_swath = old_swaths.at(s);
     F2CSwath new_swath = new_swaths.at(s);
     EXPECT_TRUE(new_swath.hasSameDir(old_swath));

--- a/tests/cpp/route_planning/route_planner_base_test.cpp
+++ b/tests/cpp/route_planning/route_planner_base_test.cpp
@@ -57,6 +57,64 @@ TEST(fields2cover_rp_route_plan_base, simple_example) {
   */
 }
 
+TEST(fields2cover_rp_route_plan_base, redirect_flag) {
+  f2c::Random rand(4);
+  F2CCells cells {
+    F2CCell(F2CLinearRing({
+          F2CPoint(0,0), F2CPoint(2,0),F2CPoint(2,2),F2CPoint(0,2), F2CPoint(0,0)
+    }))
+  };
+  cells.addRing(0, F2CLinearRing({
+          F2CPoint(.4,.4), F2CPoint(.4,.6),F2CPoint(.6,.6),F2CPoint(.6,.4), F2CPoint(.4,.4)
+  }));
+  cells.addRing(0, F2CLinearRing({
+          F2CPoint(1.2,1.2), F2CPoint(1.2,1.6),F2CPoint(1.6,1.6),F2CPoint(1.6,1.2), F2CPoint(1.2,1.2)
+  }));
+
+  cells *= 3e1;
+
+  f2c::hg::ConstHL const_hl;
+  F2CCells no_hl = const_hl.generateHeadlandArea(cells, 1, 3);
+  auto hl_swaths = const_hl.generateHeadlandSwaths(cells, 1, 3, false);
+
+  f2c::decomp::BoustrophedonDecomp decomp;
+  decomp.setSplitAngle(M_PI/2.0);
+  auto decomp_cells = decomp.decompose(no_hl);
+
+  f2c::sg::BruteForce bf;
+  F2CSwathsByCells swaths = bf.generateSwaths(M_PI/2.0, 5, decomp_cells);
+
+  f2c::rp::RoutePlannerBase route_planner;
+  F2CRoute route = route_planner.genRoute(hl_swaths[1], swaths, false, 1e-4, false);
+  
+  F2CSwaths old_swaths = swaths.flatten();
+  F2CSwaths new_swaths;
+  for (int sbc = 1; sbc < route.getVectorSwaths().size(); ++sbc){
+    new_swaths.append(route.getSwaths(sbc));
+  }
+
+  for (int s = 1; s < new_swaths.size(); ++s) {
+    F2CSwath old_swath = old_swaths.at(s);
+    F2CSwath new_swath = new_swaths.at(s);
+    EXPECT_TRUE(new_swath.hasSameDir(old_swath));
+  }
+
+  EXPECT_FALSE(route.isEmpty());
+  EXPECT_GT(route.sizeVectorSwaths(), 1);
+  EXPECT_EQ(route.sizeVectorSwaths(), route.sizeConnections());
+
+  /*
+  f2c::Visualizer::figure();
+  f2c::Visualizer::plot(cells);
+  //f2c::Visualizer::plot(no_hl);
+  //f2c::Visualizer::plot(hl_swaths[1]);
+  //f2c::Visualizer::plot(decomp_cells);
+  //for (auto&& c : route.getConnections())
+  f2c::Visualizer::plot(route);
+  f2c::Visualizer::show();
+  */
+}
+
 
 
 


### PR DESCRIPTION
Adds a flag to change the direction (or not) of the given swaths to `genRoute()`. This is useful if you care about the swath pattern/direction. This will allow users to use `SingleCellSwathsOrderBase` class with `genRoute()`. This does not enforce order, but it does enforce the pattern (direction).