### PR TITLE
Try to get ros build farm to find/use gnuplot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ FetchContent_Declare(spline FETCHCONTENT_UPDATES_DISCONNECTED
   GIT_REPOSITORY https://github.com/Fields2Cover/spline.git
   GIT_TAG 1b5d4bad29082997076b264de84ca6d46c2ae6ab
 )
+#NOTE: matplotplusplus expects to pipe commands to gnuplot at runtime
 FetchContent_Declare(matplot FETCHCONTENT_UPDATES_DISCONNECTED
   GIT_REPOSITORY https://github.com/alandefreitas/matplotplusplus
 )
@@ -108,7 +109,6 @@ FetchContent_MakeAvailable(
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(TinyXML2 REQUIRED)
 find_package(Threads REQUIRED)
-find_package(Gnuplot)
 find_package(GDAL 3.0 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_library(MATH_LIBRARY m)
@@ -359,15 +359,16 @@ endif(BUILD_PYTHON)
 ######################### test ######################
 #####################################################
 
-if(BUILD_TESTS AND GNUPLOT_FOUND)
+if(BUILD_TESTS)
   find_package(GTest REQUIRED)
+  find_package(Gnuplot REQUIRED)
   include(CTest)
   enable_testing()
   add_custom_target(check COMMAND
     GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} --verbose --test-dir tests/
   )
   add_subdirectory(tests)
-endif(BUILD_TESTS AND GNUPLOT_FOUND)
+endif(BUILD_TESTS)
 
 #####################################################
 ######################### docs ######################

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <depend>protobuf-dev</depend>
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-tk</exec_depend>
+  <exec_depend>gnuplot</exec_depend>
   <test_depend>gtest</test_depend>
   <test_depend>lcov</test_depend>
 


### PR DESCRIPTION
matplotplusplus requires gnuplot at runtime.

Add gnuplot to package.xml exec_depend
require it to be found if BUILD_TESTS.

It may also need a test_depend.