### PR TITLE
Add find_dependency(ortools REQUIRED) to Fields2CoverConfig.cmake.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ if(USE_ORTOOLS_RELEASE)
     DIRECTORY "${ortools_SOURCE_DIR}/lib/"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   )
+  install(
+    DIRECTORY "${ortools_SOURCE_DIR}/bin/"
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  )
 elseif(USE_ORTOOLS_FETCH_SRC)
   message(STATUS "or-tools -- Downloading and building from source")
   set(BUILD_DEPS ON)

--- a/cmake/Fields2CoverConfig.cmake.in
+++ b/cmake/Fields2CoverConfig.cmake.in
@@ -4,3 +4,4 @@ include("${CMAKE_CURRENT_LIST_DIR}/Fields2Cover-Targets.cmake" )
 
 include(CMakeFindDependencyMacro)
 find_dependency(GDAL 3.0 REQUIRED)
+find_dependency(ortools REQUIRED)


### PR DESCRIPTION
In order for projects like opennav_coverage to use the ortools that would come with fieldstocover we need to add the call to find_dependency to the Fields2CoverConfig.cmake.in

This also requires that the bin directory from the ortools is also "installed"