### PR TITLE
Use CMAKE_INSTALL_PREFIX to specify where to install the python interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Test Python
         working-directory: ${{github.workspace}}
-        run: pytest-3 tests/python/
+        run: PYTHONPATH=${PYTHONPATH}:instdir/lib/python$(python3 -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')/site-packages pytest-3 tests/python/
 
 
 

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -101,9 +101,9 @@ file(
 if(Python_VERSION VERSION_GREATER_EQUAL 3)
   add_custom_target(install-python
     DEPENDS _fields2cover_python
-    COMMAND python3 ${SETUP_PY_OUT} install
+    COMMAND python3 ${SETUP_PY_OUT} install --prefix=${CMAKE_INSTALL_PREFIX}
   )
-  install(CODE "execute_process(COMMAND python3 ${SETUP_PY_OUT} install)")
+  install(CODE "execute_process(COMMAND python3 ${SETUP_PY_OUT} install --prefix=${CMAKE_INSTALL_PREFIX})")
 elseif(Python_VERSION VERSION_GREATER_EQUAL 2)
   add_custom_target(
     install-python

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -20,7 +20,9 @@ class CompiledLibInstall(setuptools.command.install.install):
         filenames = '${PYTHON_INSTALL_FILES}'.split(';')
 
         # Directory to install to
-        install_dir = get_python_lib()
+        install_dir = get_python_lib(prefix=self.prefix)
+        if not os.path.isdir(install_dir):
+            os.makedirs(install_dir)
 
         # Install files
         [shutil.copy(filename, install_dir) for filename in filenames]

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -25,8 +25,9 @@ class CompiledLibInstall(setuptools.command.install.install):
             os.makedirs(install_dir)
 
         # Install files
-        [shutil.copy(filename, install_dir) for filename in filenames]
-
+        for filename in filenames:
+            print(f"Install {filename} to {install_dir}")
+            shutil.copy(filename, install_dir)
 
 # optional, use README.md as long_description
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -25,9 +25,8 @@ class CompiledLibInstall(setuptools.command.install.install):
             os.makedirs(install_dir)
 
         # Install files
-        for filename in filenames:
-            print(f"Install {filename} to {install_dir}")
-            shutil.copy(filename, install_dir)
+        [shutil.copy(filename, install_dir) for filename in filenames]
+
 
 # optional, use README.md as long_description
 this_directory = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This PR allows the python interface to be installed in the specified path. 
The default behavior is not changed.

Example:
```
cd Fields2Cover;
mkdir -p build;
cd build;
cmake -DBUILD_PYTHON=ON -DCMAKE_INSTALL_PREFIX=/tmp/test ..;
make -j$(nproc);
make install;
```
In this case, `fields2cover.py` will be installed as `/tmp/test/lib/python3.X/site-packages/fields2cover.py`

And you can run test by `PYTHONPATH=${PYTHONPATH}:/tmp/test/lib/python3.X/site-packages pytest-3 tests`