### PR TITLE
Add swig to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <depend>tinyxml2</depend>
   <depend condition="$ROS_VERSION == 2">libabsl-dev</depend>
   <depend>protobuf-dev</depend>
+  <depend>swig</depend>
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-tk</exec_depend>
   <test_depend>gtest</test_depend>


### PR DESCRIPTION
I know swig is only needed for building the python interface but is it so bad to have it as a dependency?