### PR TITLE
Increase sharpness every iteration to reduce loops

### DIFF
--- a/src/fields2cover/path_planning/dubins_curves_cc.cpp
+++ b/src/fields2cover/path_planning/dubins_curves_cc.cpp
@@ -30,7 +30,7 @@ F2CPath DubinsCurvesCC::createSimpleTurn(const F2CRobot& robot,
   while (true) {
     CC00_Dubins_State_Space ss(
         robot.getMaxCurv() / (1+0.05*n),
-        robot.getMaxDiffCurv() / (1+0.2*n),
+        robot.getMaxDiffCurv() * (1+0.2*n),
         discretization,
         true);
     if (loop_detected(ss.get_controls(start, end)) && n <= 20.) {


### PR DESCRIPTION
I believe that every iteration we want to _increase_ sharpness (diff curvature) to prevent loops rather than _decrease_ it. 