### PR TITLE
SwathGenerator fix setAllowOverlap

### DIFF
--- a/src/fields2cover/swath_generator/swath_generator_base.cpp
+++ b/src/fields2cover/swath_generator/swath_generator_base.cpp
@@ -50,16 +50,16 @@ F2CSwaths SwathGeneratorBase::generateSwaths(double angle,
 
   double curve_y {-0.5 * op_width};
   F2CMultiLineString paths;
-  while (field_height > curve_y) {
+  while (field_height > curve_y + (allow_overlap ? 1.5 * op_width : 0.5 * op_width)) {
     curve_y += op_width;
     paths.addGeometry(F2CPoint(0.0, 0.0).rotateFromPoint(angle,
         seed_curve + F2CPoint(0.0, curve_y)));
   }
  
   // Optionally, add swath to completely cover field with overlap
-  if (allow_overlap && field_height - curve_y < op_width / 2) {
-    paths.addGeometry(F2CPoint(0.0, 0.0).rotateFromPoint(angle,
-        seed_curve + F2CPoint(0.0, field_height - op_width / 2)));
+  if (allow_overlap && field_height - curve_y < 1.5 * op_width) {
+     paths.addGeometry(F2CPoint(0.0, 0.0).rotateFromPoint(angle,
+        seed_curve + F2CPoint(0.0, field_height - 0.5 * op_width)));
   }
 
   F2CSwaths swaths;

--- a/src/fields2cover/swath_generator/swath_generator_base.cpp
+++ b/src/fields2cover/swath_generator/swath_generator_base.cpp
@@ -50,10 +50,16 @@ F2CSwaths SwathGeneratorBase::generateSwaths(double angle,
 
   double curve_y {-0.5 * op_width};
   F2CMultiLineString paths;
-  while (field_height > curve_y + (allow_overlap ? 0.0 : 0.5 * op_width)) {
+  while (field_height > curve_y) {
     curve_y += op_width;
     paths.addGeometry(F2CPoint(0.0, 0.0).rotateFromPoint(angle,
         seed_curve + F2CPoint(0.0, curve_y)));
+  }
+ 
+  // Optionally, add swath to completely cover field with overlap
+  if (allow_overlap && field_height - curve_y < op_width / 2) {
+    paths.addGeometry(F2CPoint(0.0, 0.0).rotateFromPoint(angle,
+        seed_curve + F2CPoint(0.0, field_height - op_width / 2)));
   }
 
   F2CSwaths swaths;


### PR DESCRIPTION
The `setAllowOverlap()` function was not working properly (which was added in #71 ). This PR should fix this.  This option allows to have overlap between the last and one-before-last swath to completely cover the field instead of having the last swath outside the field area.

`setAllowOverlap(False)` (default):

![image](https://github.com/user-attachments/assets/d8031bb8-b1f3-45b0-8674-0b4073877cb6)

`setAllowOverlap(False)`:

![image](https://github.com/user-attachments/assets/dabf5ec2-9068-4edf-be7c-6525cc63ea9c)
