### PR TITLE
Fix v1.2.1 for ROS Jazzy/Rolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(BUILD_PYTHON "Build Python SWIG module" OFF)
 option(BUILD_DOC "Build Documentation" OFF)
 option(BUILD_SHARED_LIBS "Build shared library(.so)" ON)
 
+add_compile_options(-Wno-deprecated-declarations)
 
 
 if (BUILD_PYTHON)

--- a/include/fields2cover/types/MultiLineString.h
+++ b/include/fields2cover/types/MultiLineString.h
@@ -71,7 +71,7 @@ MultiLineString MultiLineString::Intersection(const Geometry<T, R>& g) const {
 template <class T, OGRwkbGeometryType R>
 MultiLineString MultiLineString::Intersection(
     const LineString& line, const Geometry<T, R>& g) {
-  return std::move(MultiLineString(line.get()).Intersection(g));
+  return MultiLineString(line.get()).Intersection(g);
 }
 
 

--- a/include/fields2cover/types/MultiLineString.h
+++ b/include/fields2cover/types/MultiLineString.h
@@ -71,7 +71,10 @@ MultiLineString MultiLineString::Intersection(const Geometry<T, R>& g) const {
 template <class T, OGRwkbGeometryType R>
 MultiLineString MultiLineString::Intersection(
     const LineString& line, const Geometry<T, R>& g) {
-  return MultiLineString(line.get()).Intersection(g);
+  auto inter = this->data_->Intersection(g.get());
+  f2c::types::MultiLineString lines(inter);
+  OGRGeometryFactory::destroyGeometry(inter);
+  return lines;
 }
 
 

--- a/include/fields2cover/types/Point.h
+++ b/include/fields2cover/types/Point.h
@@ -89,17 +89,11 @@ T Point::rotateFromPoint(double angle, const T& t) const {
 
 
 inline OGRPoint operator+(const OGRPoint& a, const f2c::types::Point& b) {
-  return std::move(OGRPoint(
-      a.getX() + b.getX(),
-      a.getY() + b.getY(),
-      a.getZ() + b.getZ()));
+  return {a.getX() + b.getX(), a.getY() + b.getY(), a.getZ() + b.getZ()};
 }
 
 inline OGRPoint operator-(const OGRPoint& a, const f2c::types::Point& b) {
-  return std::move(OGRPoint(
-      a.getX() - b.getX(),
-      a.getY() - b.getY(),
-      a.getZ() - b.getZ()));
+  return {a.getX() - b.getX(), a.getY() - b.getY(), a.getZ() - b.getZ()};
 }
 
 template <class T>


### PR DESCRIPTION
Currently Nav2 coverage planning still requires `v1.2.1`. Until it is moved to `v2.0.0`, which requires some effort, F2C cannot be used on ROS Jazzy/rolling.
In this PR I have fixed the build issues for this repo. I suggest making a new branch `v1.2.1-devel` and make this PR into that branch (instead of `main` which is at `v.2.0.0`).

This change was tested on Ubunu 24.04 with both Jazzy and rolling. It is ready, but I leave it as draft as the target branch should be changed.