### PR TITLE
Rework swath generator to support filling excess area

### DIFF
--- a/include/fields2cover/swath_generator/swath_generator_base.h
+++ b/include/fields2cover/swath_generator/swath_generator_base.h
@@ -14,10 +14,18 @@
 
 namespace f2c::sg {
 
-enum class SwathOverlapType {NO_OVERLAP, END_OVERLAP, MIDDLE_OVERLAP, EVENLY_DISTRIBUTED_OVERLAP};
+enum class SwathOverlapType {
+    NO_OVERLAP = 0,
+    END_OVERLAP = 1,
+    MIDDLE_OVERLAP = 2,
+    EVENLY_DISTRIBUTED_OVERLAP= 3
+};
 
 class SwathGeneratorBase {
  public:
+  SwathOverlapType getOverlapType() const;
+  void setOverlapType(SwathOverlapType);
+
   SwathOverlapType getOverlapType() const;
   void setOverlapType(SwathOverlapType);
 

--- a/include/fields2cover/swath_generator/swath_generator_base.h
+++ b/include/fields2cover/swath_generator/swath_generator_base.h
@@ -23,6 +23,9 @@ enum class SwathOverlapType {
 
 class SwathGeneratorBase {
  public:
+  bool getAllowOverlap() const;
+  void setAllowOverlap(bool);
+
   SwathOverlapType getOverlapType() const;
   void setOverlapType(SwathOverlapType);
 

--- a/include/fields2cover/swath_generator/swath_generator_base.h
+++ b/include/fields2cover/swath_generator/swath_generator_base.h
@@ -14,10 +14,12 @@
 
 namespace f2c::sg {
 
+enum class SwathOverlapType {NO_OVERLAP, END_OVERLAP, MIDDLE_OVERLAP, EVENLY_DISTRIBUTED_OVERLAP};
+
 class SwathGeneratorBase {
  public:
-  bool getAllowOverlap() const;
-  void setAllowOverlap(bool);
+  SwathOverlapType getOverlapType() const;
+  void setOverlapType(SwathOverlapType);
 
   virtual F2CSwaths generateBestSwaths(f2c::obj::SGObjective& obj,
       double op_width, const F2CCell& poly);
@@ -40,7 +42,7 @@ class SwathGeneratorBase {
   virtual ~SwathGeneratorBase() = default;
 
  protected:
-  bool allow_overlap {false};
+  SwathOverlapType overlap_type {SwathOverlapType::NO_OVERLAP};
 };
 
 }  // namespace f2c::sg

--- a/src/fields2cover/swath_generator/swath_generator_base.cpp
+++ b/src/fields2cover/swath_generator/swath_generator_base.cpp
@@ -10,6 +10,21 @@
 
 namespace f2c::sg {
 
+bool SwathGeneratorBase::getAllowOverlap() const {
+  if (this->overlap_type == SwathOverlapType::NO_OVERLAP) {
+    return false;
+  }
+  return true;
+}
+
+void SwathGeneratorBase::setAllowOverlap(bool value) {
+  if (value) {
+    this->overlap_type = SwathOverlapType::EVENLY_DISTRIBUTED_OVERLAP;
+  } else {
+    this->overlap_type = SwathOverlapType::NO_OVERLAP;
+  }
+}
+
 SwathOverlapType SwathGeneratorBase::getOverlapType() const {
   return this->overlap_type;
 }


### PR DESCRIPTION
  - fields2cover supports overlapping not all or only at the end of the path. Now, this change adds support for 4 different methods of how the excess area should be fille in.
  - NO_OVERLAP: Leave the excess area and do nothing.
  - END_OVERLAP: Add an extra pass at the end that overlaps the previous swath.
  - MIDDLE_OVERLAP: Add an extra pass to the middle and any middle swath will overlap (excludes outside swaths so that the outside swaths stay consistent with the desired width).
  - EVENLY_DISTRIBUTED_OVERLAP: Distribute the overlap evenly to all the swaths, including the outside swaths.
  - Remove allowOverlap parameter as it is redundant with NO_OVERLAP