### PR TITLE
Update cmake testing option to standard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
             -DBUILD_PYTHON=ON   \
             -DALLOW_PARALLELIZATION=ON  \
             -DBUILD_TUTORIALS=OFF \
-            -DBUILD_TESTS=ON   \
+            -DBUILD_TESTING=ON   \
             -DBUILD_DOC=OFF \
             -DBUILD_SHARED_LIBS={{ matrix.shared }} \
             -DUSE_ORTOOLS_RELEASE=ON \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -92,7 +92,7 @@ jobs:
             -DBUILD_PYTHON=OFF   \
             -DALLOW_PARALLELIZATION=ON  \
             -DBUILD_TUTORIALS=OFF \
-            -DBUILD_TESTS=ON   \
+            -DBUILD_TESTING=ON   \
             -DBUILD_DOC=ON
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ project(Fields2Cover
 
 option(ALLOW_PARALLELIZATION "Allow parallel algorithms" ON)
 option(BUILD_TUTORIALS "Build tutorials" ON)
-option(BUILD_TESTS "Build tests" ON)
 option(BUILD_PYTHON "Build Python SWIG module" ON)
 option(BUILD_DOC "Build Documentation" OFF)
 option(BUILD_SHARED_LIBS "Build shared library(.so)" ON)
@@ -166,7 +165,7 @@ endif(BUILD_PYTHON)
 ######################### test ######################
 #####################################################
 
-if(BUILD_TESTS AND GNUPLOT_FOUND)
+if(BUILD_TESTING AND GNUPLOT_FOUND)
   find_package(GTest REQUIRED)
   include(CTest)
   enable_testing()
@@ -174,7 +173,7 @@ if(BUILD_TESTS AND GNUPLOT_FOUND)
     GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} --verbose --test-dir tests/
   )
   add_subdirectory(tests)
-endif(BUILD_TESTS AND GNUPLOT_FOUND)
+endif(BUILD_TESTING AND GNUPLOT_FOUND)
 
 #####################################################
 ######################### docs ######################

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ WORKDIR /workspace/fields2cover/build
 
 RUN cmake -DBUILD_PYTHON=ON \
     -DBUILD_TUTORIALS=OFF \
-    -DBUILD_TESTS=ON \
+    -DBUILD_TESTING=ON \
     -DBUILD_DOC=OFF \
     -DCMAKE_BUILD_TYPE=Release ..
 


### PR DESCRIPTION
Minor update to make the testing cmake option conform to the cmake standard so tools like colcon will properly enable/disable testing with mixins.  Addresses #195.