### PR TITLE
Disable visualizer and tutorials by default, fix Python deprecation w…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,14 @@ project(Fields2Cover
 
 
 option(ALLOW_PARALLELIZATION "Allow parallel algorithms" ON)
-option(BUILD_TUTORIALS "Build tutorials" ON)
+option(BUILD_TUTORIALS "Build tutorials" OFF)
 option(BUILD_PYTHON "Build Python SWIG module" ON)
 option(BUILD_DOC "Build Documentation" OFF)
 option(BUILD_SHARED_LIBS "Build shared library(.so)" ON)
 option(USE_ORTOOLS_RELEASE "Get or-tools from release tarball" OFF)
 option(USE_ORTOOLS_FETCH_SRC "Get or-tools from source" OFF)
 option(USE_ORTOOLS_VENDOR "Get or-tools from ortools_vendor" OFF)
+option(BUILD_VISUALIZER "Build visualization support (requires matplotplusplus)" OFF)
 
 
 # Set C++ standard
@@ -65,6 +66,9 @@ f2c_declare_dependencies()
 file(GLOB_RECURSE fields2cover_src
   "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
 )
+if(NOT BUILD_VISUALIZER)
+  list(FILTER fields2cover_src EXCLUDE REGEX ".*/utils/visualizer\\.cpp$")
+endif()
 
 add_library(Fields2Cover ${fields2cover_src})
 
@@ -88,8 +92,11 @@ target_link_libraries(Fields2Cover
     nlohmann_json::nlohmann_json
     tinyxml2::tinyxml2
     steering_functions
-    matplot
 )
+if(BUILD_VISUALIZER)
+  target_link_libraries(Fields2Cover PRIVATE matplot)
+  target_compile_definitions(Fields2Cover PUBLIC FIELDS2COVER_BUILD_VISUALIZER)
+endif()
 
 if(ALLOW_PARALLELIZATION)
   target_link_libraries(Fields2Cover PRIVATE tbb)
@@ -106,7 +113,12 @@ f2c_set_compiler_options(Fields2Cover)
 include(GNUInstallDirs)
 set(F2C_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/Fields2Cover)
 
-install(TARGETS Fields2Cover steering_functions matplot
+if(BUILD_VISUALIZER)
+  set(F2C_INSTALL_TARGETS Fields2Cover steering_functions matplot)
+else()
+  set(F2C_INSTALL_TARGETS Fields2Cover steering_functions)
+endif()
+install(TARGETS ${F2C_INSTALL_TARGETS}
   EXPORT Fields2CoverTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cmake/F2CUtils.cmake
+++ b/cmake/F2CUtils.cmake
@@ -71,15 +71,19 @@ function(f2c_declare_dependencies)
     GIT_REPOSITORY https://github.com/Fields2Cover/steering_functions.git
     GIT_TAG 13e3f5658144b3832fb1eb31a0e2f5a3cbf57db9
   )
-  FetchContent_Declare(matplot FETCHCONTENT_UPDATES_DISCONNECTED
-    GIT_REPOSITORY https://github.com/alandefreitas/matplotplusplus.git
-    GIT_TAG 5d01eb3695b07634a2b6642fd423740dea9b026c
-  )
 
   FetchContent_Declare(json FETCHCONTENT_UPDATES_DISCONNECTED
     GIT_REPOSITORY https://github.com/nlohmann/json.git
     GIT_TAG 4424a0fcc1c7fa640b5c87d26776d99150dacd10
   )
 
-  FetchContent_MakeAvailable(steering_functions matplot json)
+  if(BUILD_VISUALIZER)
+    FetchContent_Declare(matplot FETCHCONTENT_UPDATES_DISCONNECTED
+      GIT_REPOSITORY https://github.com/alandefreitas/matplotplusplus.git
+      GIT_TAG 5d01eb3695b07634a2b6642fd423740dea9b026c
+    )
+    FetchContent_MakeAvailable(steering_functions matplot json)
+  else()
+    FetchContent_MakeAvailable(steering_functions json)
+  endif()
 endfunction()

--- a/include/fields2cover.h
+++ b/include/fields2cover.h
@@ -15,7 +15,9 @@
 #include "fields2cover/utils/spline.h"
 #include "fields2cover/utils/transformation.h"
 #include "fields2cover/utils/parser.h"
+#ifdef FIELDS2COVER_BUILD_VISUALIZER
 #include "fields2cover/utils/visualizer.h"
+#endif
 
 
 #include "fields2cover/objectives/base_objective.h"

--- a/swig/Fields2Cover.i
+++ b/swig/Fields2Cover.i
@@ -180,7 +180,9 @@ typedef long unsigned int size_t;
 %include "fields2cover/utils/random.h"
 %include "fields2cover/utils/spline.h"
 %include "fields2cover/utils/parser.h"
+#ifdef FIELDS2COVER_BUILD_VISUALIZER
 %include "fields2cover/utils/visualizer.h"
+#endif
 
 
 %ignore f2c::Transform::generateCoordTransf;

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -9,6 +9,9 @@ find_package(
 if(Python_VERSION VERSION_GREATER_EQUAL 3)
   list(APPEND CMAKE_SWIG_FLAGS "-py3;-DPY3")
 endif()
+if(BUILD_VISUALIZER)
+  list(APPEND CMAKE_SWIG_FLAGS "-DFIELDS2COVER_BUILD_VISUALIZER")
+endif()
 
 if(BUILD_DOC)
   list(APPEND CMAKE_SWIG_FLAGS "-doxygen")
@@ -91,23 +94,12 @@ file(
 )
 
 
-# Install target to call setup.py
-if(Python_VERSION VERSION_GREATER_EQUAL 3)
-  add_custom_target(install-python
-    DEPENDS _fields2cover_python
-    COMMAND python3 ${SETUP_PY_OUT} install --prefix=${CMAKE_INSTALL_PREFIX}
-  )
-  install(CODE "execute_process(COMMAND python3 ${SETUP_PY_OUT} install --prefix=${CMAKE_INSTALL_PREFIX})")
-elseif(Python_VERSION VERSION_GREATER_EQUAL 2)
-  add_custom_target(
-    install-python
-    DEPENDS
-      _fields2cover_python
-    COMMAND
-      python ${SETUP_PY_OUT} install
-  )
-  install(CODE "execute_process(COMMAND python ${SETUP_PY_OUT} install)")
-endif()
+# Install Python files directly using CMake
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/fields2cover.py
+  $<TARGET_FILE:fields2cover_python>
+  DESTINATION lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/dist-packages
+)
 
 
 

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -1,5 +1,5 @@
 import os
-from distutils.sysconfig import get_python_lib
+import sysconfig
 from setuptools import setup
 import setuptools.command.install
 from setuptools.extension import Extension
@@ -20,7 +20,7 @@ class CompiledLibInstall(setuptools.command.install.install):
         filenames = '${PYTHON_INSTALL_FILES}'.split(';')
 
         # Directory to install to
-        install_dir = get_python_lib(prefix=self.prefix)
+        install_dir = sysconfig.get_path('purelib', vars={'base': self.prefix, 'platbase': self.prefix})
         if not os.path.isdir(install_dir):
             os.makedirs(install_dir)
 


### PR DESCRIPTION
…arnings

- Add BUILD_VISUALIZER option (default OFF) to skip matplotplusplus build. matplot, visualizer.cpp, and related SWIG bindings are excluded when OFF.
- Change BUILD_TUTORIALS default to OFF since tutorials depend on Visualizer.
- Guard visualizer.h include in fields2cover.h with FIELDS2COVER_BUILD_VISUALIZER.
- Guard visualizer.h in SWIG .i file with #ifdef FIELDS2COVER_BUILD_VISUALIZER.
- Replace deprecated distutils.sysconfig with sysconfig in setup.py.in.
- Replace 'python setup.py install' with CMake install(FILES ...) to eliminate SetuptoolsDeprecationWarning.