### PR TITLE
Fix segfault in FieldCoverage::computeCost when swaths is empty

### DIFF
--- a/src/fields2cover/objectives/sg_obj/field_coverage.cpp
+++ b/src/fields2cover/objectives/sg_obj/field_coverage.cpp
@@ -15,6 +15,10 @@ double FieldCoverage::computeCost(
 
 double FieldCoverage::computeCost(
     const F2CCells& poly, const F2CSwaths& swaths) {
+  if (swaths.size() == 0) {
+    return 0.0;
+  }
+
   F2CMultiLineString lines;
   for (const auto& s : swaths) {
     lines.addGeometry(s.getPath());

--- a/src/fields2cover/objectives/sg_obj/field_coverage.cpp
+++ b/src/fields2cover/objectives/sg_obj/field_coverage.cpp
@@ -26,7 +26,7 @@ double FieldCoverage::computeCost(
 
   double area_covered {poly.getCellsInside(
       F2CCells::buffer(lines, swaths[0].getWidth() / 2.0)).area()};
-  return area_covered / poly.area();
+  return area_covered / (poly.area() + 1e-7);
 }
 
 bool FieldCoverage::isMinimizing() const {

--- a/tests/cpp/objectives/sg_obj/field_coverage_test.cpp
+++ b/tests/cpp/objectives/sg_obj/field_coverage_test.cpp
@@ -79,6 +79,24 @@ TEST(fields2cover_obj_field_coverage, computeCost_cost) {
   EXPECT_EQ(coverage.computeCostWithMinimizingSign(fields, swaths_half), -0.5);
 }
 
+TEST(fields2cover_obj_field_coverage, empty_swaths) {
+  F2CCell field;
+  F2CLinearRing line;
+  line.addPoint(0, 0);
+  line.addPoint(4, 0);
+  line.addPoint(4, 4);
+  line.addPoint(0, 4);
+  line.addPoint(0, 0);
+  field.addRing(line);
+  F2CCells fields{field};
+
+  F2CSwaths swaths;
+
+  f2c::obj::FieldCoverage obj;
+  EXPECT_EQ(obj.computeCost(field, swaths), 0.0);
+  EXPECT_EQ(obj.computeCost(fields, swaths), 0.0);
+}
+
 TEST(fields2cover_obj_field_coverage, params_check) {
   f2c::obj::FieldCoverage objective;
   EXPECT_TRUE(objective.isMaximizing());


### PR DESCRIPTION
Closes #221.

When a field is small enough that the headland consumes nearly all the area, the swath generator can return zero swaths. `FieldCoverage::computeCost` then reads `swaths[0].getWidth()` on line 24, which indexes past the end of the swath vector and segfaults.

This returns a cost of 0.0 when there are no swaths, matching the issue author's reasoning: no swaths cover no area, so the coverage ratio is 0. Added a regression test that exercises the empty-swaths path against both `computeCost` overloads.
