### PR TITLE
Fix UTM zone regex rejected by libc++ at runtime

### DIFF
--- a/src/fields2cover/types/Field.cpp
+++ b/src/fields2cover/types/Field.cpp
@@ -99,7 +99,7 @@ std::string Field::getUTMCoordSystem(
     const std::string& coord_sys, const std::string& if_not_found) {
   std::smatch match;
   if (std::regex_search(coord_sys, match,
-        std::regex("UTM[^0-9A-Za-z]*(\\d++\\w)[^\\w]*"))) {
+        std::regex("UTM[^0-9A-Za-z]*(\\d+\\w)[^\\w]*"))) {
     return match.str(1);
   }
   return if_not_found;


### PR DESCRIPTION
`Field::getUTMCoordSystem` uses `\d++` — a possessive quantifier, which isn't part of the ECMAScript grammar `std::regex` uses by default. libc++ (the macOS default) throws `std::regex_error` at runtime on **every** `Transform::transformToUTM` call, so no GPS↔UTM workflow runs. libstdc++ happens to tolerate it, which is why Linux CI never sees it.

Fix: `\d++` → `\d+` (matches identically here — the possessive semantics were never needed).

<details><summary>Verification</summary>

Full build + C++ and Python test suites pass on macOS 14 (Apple Silicon, AppleClang/libc++) with this change.
</details>


---
*Authored with [Claude Fable 5](https://claude.com/claude-code).*