### PR TITLE
Don't link libpython into the Python module on macOS

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -30,12 +30,18 @@ SWIG_ADD_LIBRARY(fields2cover_python
   LANGUAGE python
   SOURCES ../${PROJECT_NAME}.i
 )
+# Don't link libpython on macOS: resolve Python symbols at load time so the
+# module works with any CPython 3.13, not just the one it was built against.
 SWIG_LINK_LIBRARIES(fields2cover_python
   Fields2Cover
-  ${Python_LIBRARIES}
   ${PROJ_LIBRARY}
   ${GDAL_LIBRARIES}
 )
+if(APPLE)
+  set_target_properties(fields2cover_python PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+else()
+  SWIG_LINK_LIBRARIES(fields2cover_python ${Python_LIBRARIES})
+endif()
 
 # Files to install with Python
 set(

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -31,7 +31,8 @@ SWIG_ADD_LIBRARY(fields2cover_python
   SOURCES ../${PROJECT_NAME}.i
 )
 # Don't link libpython on macOS: resolve Python symbols at load time so the
-# module works with any CPython 3.13, not just the one it was built against.
+# module isn't pinned to the exact libpython it was built against (it stays
+# ABI-bound to that Python minor version).
 SWIG_LINK_LIBRARIES(fields2cover_python
   Fields2Cover
   ${PROJ_LIBRARY}


### PR DESCRIPTION
The SWIG module links `${Python_LIBRARIES}`, pinning it to the exact libpython it was built against. On `APPLE`, leave Python symbols undefined and resolve them at load time via `-undefined dynamic_lookup` — the conventional approach for CPython extension modules on macOS. Linux keeps linking `${Python_LIBRARIES}` unchanged.

<details><summary>Notes</summary>

The module stays ABI-bound to the Python minor version it was built for; `dynamic_lookup` only decouples it from the libpython *binary*. A cleaner route would be the `Python::Module` imported target, but that needs CMake ≥ 3.15 while this project requires 3.12.4.
</details>


---
*Authored with [Claude Fable 5](https://claude.com/claude-code).*