### PR TITLE
Include GDAL headers without the distro-specific gdal/ prefix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,11 +9,6 @@ LABEL NAME="fields2cover" \
 ENV DEBIAN_FRONTEND noninteractive
 
 WORKDIR /workspaces/
-RUN mkdir -p /usr/include/new_gdal && \
-    cp -r /usr/include/gdal* /usr/include/new_gdal/ && \
-    cp /usr/include/ogr* /usr/include/new_gdal/ && \
-    cp /usr/include/cpl* /usr/include/new_gdal/ && \
-    mv /usr/include/new_gdal/ /usr/include/gdal/
 
 RUN apt-get update --allow-insecure-repositories -y && \
     apt-get install -y --allow-unauthenticated --no-install-recommends ca-certificates

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,15 +73,6 @@ jobs:
           make -j2
           make install
 
-      - name: Configure GDAL
-        shell: bash
-        run: |
-          mkdir -p /usr/include/new_gdal
-          cp -r /usr/include/gdal* /usr/include/new_gdal/
-          cp /usr/include/ogr* /usr/include/new_gdal/
-          cp /usr/include/cpl* /usr/include/new_gdal/
-          mv /usr/include/new_gdal/ /usr/include/gdal/
-
       - name: Configure Or-tools
         shell: bash
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,15 +55,6 @@ jobs:
           cp *.a /usr/lib/ 2>\dev\null || :
           cp lib/*.a /usr/lib/ 2>\dev\null || :
 
-      - name: Configure GDAL
-        shell: bash
-        run: |
-          mkdir -p /usr/include/new_gdal
-          cp -r /usr/include/gdal* /usr/include/new_gdal/
-          cp /usr/include/ogr* /usr/include/new_gdal/
-          cp /usr/include/cpl* /usr/include/new_gdal/
-          mv /usr/include/new_gdal/ /usr/include/gdal/
-
       - name: Configure Or-tools
         shell: bash
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,6 @@ LABEL NAME="fields2cover" \
 ENV DEBIAN_FRONTEND noninteractive
 
 WORKDIR /workspaces/
-RUN mkdir -p /usr/include/new_gdal && \
-    cp -r /usr/include/gdal* /usr/include/new_gdal/ && \
-    cp /usr/include/ogr* /usr/include/new_gdal/ && \
-    cp /usr/include/cpl* /usr/include/new_gdal/ && \
-    mv /usr/include/new_gdal/ /usr/include/gdal/
 
 RUN apt-get update --allow-insecure-repositories -y && \
     apt-get install -y --allow-unauthenticated --no-install-recommends ca-certificates

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,11 +9,6 @@ LABEL NAME="fields2cover" \
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /workspaces/
-RUN mkdir -p /usr/include/new_gdal && \
-    cp -r /usr/include/gdal* /usr/include/new_gdal/ && \
-    cp /usr/include/ogr* /usr/include/new_gdal/ && \
-    cp /usr/include/cpl* /usr/include/new_gdal/ && \
-    mv /usr/include/new_gdal/ /usr/include/gdal/
 
 RUN apt-get update --allow-insecure-repositories -y && \
     apt-get install -y --allow-unauthenticated --no-install-recommends ca-certificates

--- a/include/fields2cover/types.h
+++ b/include/fields2cover/types.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_H_
 #define FIELDS2COVER_TYPES_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <vector>
 
 

--- a/include/fields2cover/types/Cell.h
+++ b/include/fields2cover/types/Cell.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_CELL_H_
 #define FIELDS2COVER_TYPES_CELL_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <string>
 #include <boost/math/constants/constants.hpp>
 #include "fields2cover/types/Geometries.h"

--- a/include/fields2cover/types/Cells.h
+++ b/include/fields2cover/types/Cells.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_CELLS_H_
 #define FIELDS2COVER_TYPES_CELLS_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <vector>
 #include "fields2cover/types/Geometry.h"
 #include "fields2cover/types/Geometries.h"

--- a/include/fields2cover/types/Geometries.h
+++ b/include/fields2cover/types/Geometries.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_GEOMETRIES_H_
 #define FIELDS2COVER_TYPES_GEOMETRIES_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <memory>
 #include <type_traits>
 #include <iterator>

--- a/include/fields2cover/types/Geometry.h
+++ b/include/fields2cover/types/Geometry.h
@@ -8,8 +8,8 @@
 #ifndef FIELDS2COVER_TYPES_GEOMETRY_H_
 #define FIELDS2COVER_TYPES_GEOMETRY_H_
 
-#include <gdal/ogr_geometry.h>
-#include <gdal/ogr_core.h>
+#include <ogr_geometry.h>
+#include <ogr_core.h>
 #include <functional>
 #include <memory>
 #include <vector>

--- a/include/fields2cover/types/Geometry_impl.hpp
+++ b/include/fields2cover/types/Geometry_impl.hpp
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_GEOMETRY_IMPL_HPP_
 #define FIELDS2COVER_TYPES_GEOMETRY_IMPL_HPP_
 
-#include <gdal/cpl_conv.h>
+#include <cpl_conv.h>
 #include <geos_c.h>
 #include <memory>
 #include <vector>

--- a/include/fields2cover/types/LineString.h
+++ b/include/fields2cover/types/LineString.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_LINESTRING_H_
 #define FIELDS2COVER_TYPES_LINESTRING_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <vector>
 #include "fields2cover/types/Geometries.h"
 #include "fields2cover/types/Point.h"

--- a/include/fields2cover/types/LinearRing.h
+++ b/include/fields2cover/types/LinearRing.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_LINEARRING_H_
 #define FIELDS2COVER_TYPES_LINEARRING_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <vector>
 #include "fields2cover/types/Geometries.h"
 #include "fields2cover/types/Point.h"

--- a/include/fields2cover/types/MultiLineString.h
+++ b/include/fields2cover/types/MultiLineString.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_MULTILINESTRING_H_
 #define FIELDS2COVER_TYPES_MULTILINESTRING_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <utility>
 #include "fields2cover/types/Geometries.h"
 #include "fields2cover/types/LineString.h"

--- a/include/fields2cover/types/MultiPoint.h
+++ b/include/fields2cover/types/MultiPoint.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_MULTIPOINT_H_
 #define FIELDS2COVER_TYPES_MULTIPOINT_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <vector>
 #include "fields2cover/types/Geometries.h"
 #include "fields2cover/types/Point.h"

--- a/include/fields2cover/types/Path.h
+++ b/include/fields2cover/types/Path.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_PATH_H_
 #define FIELDS2COVER_TYPES_PATH_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <fstream>
 #include <vector>
 #include <string>

--- a/include/fields2cover/types/Point.h
+++ b/include/fields2cover/types/Point.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_POINT_H_
 #define FIELDS2COVER_TYPES_POINT_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <iostream>
 #include <functional>
 #include <memory>

--- a/include/fields2cover/types/Robot.h
+++ b/include/fields2cover/types/Robot.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_ROBOT_H_
 #define FIELDS2COVER_TYPES_ROBOT_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <utility>
 #include <string>
 #include <vector>

--- a/include/fields2cover/types/Route.h
+++ b/include/fields2cover/types/Route.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_ROUTE_H_
 #define FIELDS2COVER_TYPES_ROUTE_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 #include <vector>
 #include <numeric>
 #include <optional>

--- a/include/fields2cover/types/Swath.h
+++ b/include/fields2cover/types/Swath.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_TYPES_SWATH_H_
 #define FIELDS2COVER_TYPES_SWATH_H_
 
-#include <gdal/ogr_geometry.h>
+#include <ogr_geometry.h>
 
 #include <algorithm>
 #include <memory>

--- a/include/fields2cover/utils/transformation.h
+++ b/include/fields2cover/utils/transformation.h
@@ -8,7 +8,7 @@
 #ifndef FIELDS2COVER_UTILS_TRANSFORMATION_H_
 #define FIELDS2COVER_UTILS_TRANSFORMATION_H_
 
-#include <gdal/ogr_spatialref.h>
+#include <ogr_spatialref.h>
 #include <memory>
 #include <utility>
 #include <string>


### PR DESCRIPTION
Headers include `<gdal/ogr_geometry.h>` etc. The `gdal/` subdirectory is a Debian/Ubuntu packaging detail — GDAL installs its headers flat, so on macOS (Homebrew) and other layouts the prefixed form isn't found. Since these headers are installed, this also breaks downstream C++ consumers.

Fix: use the prefix-free form. The include directory is already provided by the linked `GDAL::GDAL` target on every platform (on Ubuntu it points at `/usr/include/gdal`, so the prefix-free form resolves there too). This also lets the "Configure GDAL" CI step — which manually recreated the `gdal/` layout inside the `osgeo/gdal` containers — be removed, so the same CI now proves the fix.

Related to #205.

<details><summary>Note for non-CMake consumers</summary>

Non-CMake consumers on Debian who relied on the `gdal/` prefix now need `-I/usr/include/gdal` on the compiler line. CMake consumers get it automatically from `GDAL::GDAL`.
</details>


---
*Authored with [Claude Fable 5](https://claude.com/claude-code).*