### PR TITLE
Find GEOS and TBB via find_package with imported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ if(ALLOW_PARALLELIZATION)
   # Prefer the imported target from oneTBB's CMake config; fall back to the
   # bare library name for distros that don't ship the config.
   find_package(TBB CONFIG QUIET)
+  set(F2C_TBB_FROM_CONFIG ${TBB_FOUND})  # consumed by Fields2CoverConfig.cmake.in
   if(TBB_FOUND)
     target_link_libraries(Fields2Cover PRIVATE TBB::tbb)
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,16 @@ find_package(GDAL 3.0 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_library(MATH_LIBRARY m)
 
+# Prefer the imported target from GEOS' CMake config (available since GEOS 3.8);
+# fall back to the bare linker flag for distros that don't ship the config.
+find_package(GEOS CONFIG QUIET)
+set(F2C_GEOS_FROM_CONFIG ${GEOS_FOUND})  # consumed by Fields2CoverConfig.cmake.in
+if(GEOS_FOUND)
+  set(F2C_GEOS_C_LIBRARY GEOS::geos_c)
+else()
+  set(F2C_GEOS_C_LIBRARY -lgeos_c)
+endif()
+
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -81,7 +91,7 @@ target_link_libraries(Fields2Cover
   PUBLIC
     GDAL::GDAL
     ${CMAKE_THREAD_LIBS_INIT}
-    -lgeos_c
+    ${F2C_GEOS_C_LIBRARY}
     ${MATH_LIBRARY}
   PRIVATE
     ortools::ortools
@@ -92,7 +102,14 @@ target_link_libraries(Fields2Cover
 )
 
 if(ALLOW_PARALLELIZATION)
-  target_link_libraries(Fields2Cover PRIVATE tbb)
+  # Prefer the imported target from oneTBB's CMake config; fall back to the
+  # bare library name for distros that don't ship the config.
+  find_package(TBB CONFIG QUIET)
+  if(TBB_FOUND)
+    target_link_libraries(Fields2Cover PRIVATE TBB::tbb)
+  else()
+    target_link_libraries(Fields2Cover PRIVATE tbb)
+  endif()
 endif(ALLOW_PARALLELIZATION)
 
 

--- a/cmake/Fields2CoverConfig.cmake.in
+++ b/cmake/Fields2CoverConfig.cmake.in
@@ -8,6 +8,11 @@ include(CMakeFindDependencyMacro)
 find_dependency(GDAL 3.0 REQUIRED)
 find_dependency(Threads REQUIRED)
 find_dependency(Eigen3 REQUIRED)
+if(@F2C_GEOS_FROM_CONFIG@)
+  # the exported target links GEOS::geos_c (only when GEOS' CMake config was
+  # found at build time; otherwise the plain -lgeos_c flag needs no package)
+  find_dependency(GEOS CONFIG REQUIRED)
+endif()
 
 # Optional dependencies
 if(@F2C_ALLOW_PARALLELIZATION@)

--- a/cmake/Fields2CoverConfig.cmake.in
+++ b/cmake/Fields2CoverConfig.cmake.in
@@ -15,8 +15,10 @@ if(@F2C_GEOS_FROM_CONFIG@)
 endif()
 
 # Optional dependencies
-if(@F2C_ALLOW_PARALLELIZATION@)
-  find_dependency(TBB REQUIRED)
+if(@F2C_TBB_FROM_CONFIG@)
+  # the exported target links TBB::tbb (only when oneTBB's CMake config was
+  # found at build time; otherwise the plain -ltbb flag needs no package)
+  find_dependency(TBB CONFIG REQUIRED)
 endif()
 
 set_and_check(Fields2Cover_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")


### PR DESCRIPTION
The build hard-codes `-lgeos_c` and the bare `tbb` library name, which are only found when the libraries sit on the default linker path — not the case for Homebrew on macOS. Prefer the CMake configs both projects ship (`GEOS::geos_c` since GEOS 3.8, `TBB::tbb` in oneTBB) via `find_package(... CONFIG QUIET)`, falling back to the old bare names where they aren't available.

<details><summary>Config export</summary>

`GEOS::geos_c` is a PUBLIC link dependency, so it ends up in the exported targets. `Fields2CoverConfig.cmake.in` now calls `find_dependency(GEOS CONFIG)` — but only in the branch where the config was actually used at build time, so the plain `-lgeos_c` fallback needs no GEOS package downstream.
</details>

Related to #205.


---
*Authored with [Claude Fable 5](https://claude.com/claude-code).*