### PR TITLE
Fail early with guidance when no or-tools tarball fits the platform

### DIFF
--- a/cmake/F2CUtils.cmake
+++ b/cmake/F2CUtils.cmake
@@ -27,7 +27,6 @@ function(f2c_declare_dependencies)
     find_package(ortools_vendor QUIET)
     find_package(ortools CONFIG QUIET)
     if(NOT ortools_FOUND)
-      message(STATUS "or-tools -- Downloading and installing from release tarball")
       if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
         message(FATAL_ERROR
           "or-tools was not found and the release tarballs below are Linux-only "
@@ -36,12 +35,14 @@ function(f2c_declare_dependencies)
           "on macOS) and pass -DCMAKE_PREFIX_PATH so find_package can locate it, "
           "or build it from source with -DUSE_ORTOOLS_FETCH_SRC=ON.")
       elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+        message(STATUS "or-tools -- Downloading and installing from release tarball")
         message(STATUS "Target architecture is AMD64")
         FetchContent_Declare(ortools FETCHCONTENT_UPDATES_DISCONNECTED
           URL https://github.com/google/or-tools/releases/download/v9.9/or-tools_amd64_ubuntu-22.04_cpp_v9.9.3963.tar.gz
           URL_HASH SHA256=a611133f4e9b75661c637347ebadff79539807cf8966eb9c176c2c560aad0a84
         )
       elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        message(STATUS "or-tools -- Downloading and installing from release tarball")
         message(STATUS "Target architecture is ARM64")
         FetchContent_Declare(ortools FETCHCONTENT_UPDATES_DISCONNECTED
           URL https://github.com/google/or-tools/releases/download/v9.9/or-tools_arm64_debian-11_cpp_v9.9.3963.tar.gz

--- a/cmake/F2CUtils.cmake
+++ b/cmake/F2CUtils.cmake
@@ -28,7 +28,14 @@ function(f2c_declare_dependencies)
     find_package(ortools CONFIG QUIET)
     if(NOT ortools_FOUND)
       message(STATUS "or-tools -- Downloading and installing from release tarball")
-      if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+      if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        message(FATAL_ERROR
+          "or-tools was not found and the release tarballs below are Linux-only "
+          "(current platform: ${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}). "
+          "Install or-tools with your package manager (e.g. `brew install or-tools` "
+          "on macOS) and pass -DCMAKE_PREFIX_PATH so find_package can locate it, "
+          "or build it from source with -DUSE_ORTOOLS_FETCH_SRC=ON.")
+      elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
         message(STATUS "Target architecture is AMD64")
         FetchContent_Declare(ortools FETCHCONTENT_UPDATES_DISCONNECTED
           URL https://github.com/google/or-tools/releases/download/v9.9/or-tools_amd64_ubuntu-22.04_cpp_v9.9.3963.tar.gz
@@ -41,7 +48,11 @@ function(f2c_declare_dependencies)
           URL_HASH SHA256=f308a06d89dce060f74e6fec4936b43f4bdf4874d18c131798697756200f4e7a
         )
       else()
-        message(FATAL_ERROR "Unknown/Unhandled target architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+        message(FATAL_ERROR
+          "No or-tools release tarball is available for this architecture "
+          "(${CMAKE_SYSTEM_PROCESSOR}). Install or-tools with your package "
+          "manager and pass -DCMAKE_PREFIX_PATH so find_package can locate it, "
+          "or build it from source with -DUSE_ORTOOLS_FETCH_SRC=ON.")
       endif()
       #NOTE: FetchContent_GetProperties variables only available in called scope
       FetchContent_GetProperties(ortools)


### PR DESCRIPTION
When `find_package(ortools)` fails, the fallback downloads a release tarball — but only Linux tarballs exist. On macOS x86_64 it silently fetched an Ubuntu binary that could never link; on Apple Silicon it hit an unhelpful "Unknown/Unhandled target architecture" error.

Fix: bail out before downloading on non-Linux platforms with an actionable message — install or-tools via a package manager (e.g. `brew install or-tools`) and pass `-DCMAKE_PREFIX_PATH`, or build from source with `-DUSE_ORTOOLS_FETCH_SRC=ON`. The unknown-architecture branch gets the same guidance.


---
*Authored with [Claude Fable 5](https://claude.com/claude-code).*