### PR TITLE
Small API additions: Route::reverse, TurningBase::hasContinuousCurvature, public getSmoothTurningRadius

### DIFF
--- a/include/fields2cover/path_planning/dubins_curves_cc.h
+++ b/include/fields2cover/path_planning/dubins_curves_cc.h
@@ -19,6 +19,7 @@ class DubinsCurvesCC : public TurningBase {
   F2CPath createSimpleTurn(const F2CRobot& robot,
       double dist_start_pos, double start_angle,
       double end_angle) override;
+  bool hasContinuousCurvature() const override;
   F2CPath createConstrainedTurn(const F2CRobot& robot,
       const F2CPoint& start_pos, double start_angle, double start_curvature,
       const F2CPoint& end_pos, double end_angle, double end_curvature, const bool fix_loops=false);

--- a/include/fields2cover/path_planning/path_planning.h
+++ b/include/fields2cover/path_planning/path_planning.h
@@ -40,8 +40,11 @@ class PathPlanning {
       const F2CPoint& p2, double ang2,
       TurningBase& turn);
 
- private:
+  /// Radius swept by a turn with continuous curvature. Wider than the minimum
+  /// turning radius, as the clothoid ramps spend part of the deflection.
   static double getSmoothTurningRadius(const F2CRobot& robot);
+
+ private:
   static std::vector<std::pair<F2CPoint, double>> simplifyConnection(
       const F2CRobot& robot,
       const F2CPoint& p1, double ang1,

--- a/include/fields2cover/path_planning/reeds_shepp_curves_hc.h
+++ b/include/fields2cover/path_planning/reeds_shepp_curves_hc.h
@@ -18,6 +18,7 @@ class ReedsSheppCurvesHC : public TurningBase {
  public:
   F2CPath createSimpleTurn(const F2CRobot& robot,
       double dist_start_pos, double start_angle, double end_angle) override;
+  bool hasContinuousCurvature() const override;
 };
 
 }  // namespace f2c::pp

--- a/include/fields2cover/path_planning/turning_base.h
+++ b/include/fields2cover/path_planning/turning_base.h
@@ -50,6 +50,9 @@ class TurningBase {
   virtual F2CPath createSimpleTurn(const F2CRobot& robot, double dist_start_pos,
       double start_angle, double end_angle) = 0;
 
+  /// Check if the turns keep the curvature continuous.
+  virtual bool hasContinuousCurvature() const;
+
   /// @brief Transform the turn parameters representation from two points with
   /// two angles to one distance and two angles.
   /// @param start_pos Start point

--- a/include/fields2cover/types/Route.h
+++ b/include/fields2cover/types/Route.h
@@ -9,6 +9,7 @@
 #define FIELDS2COVER_TYPES_ROUTE_H_
 
 #include <ogr_geometry.h>
+#include <algorithm>
 #include <vector>
 #include <numeric>
 #include <optional>
@@ -59,6 +60,10 @@ struct Route {
   LineString asLineString() const;
 
   bool isEmpty() const;
+
+  /// Reverse the route, so it is driven from the end point to the start point.
+  void reverse();
+
   Route clone() const;
 
  private:

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
 
 <package format="3">
   <name>fields2cover</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>
     Robust and efficient coverage paths for autonomous agricultural vehicles.
     A modular and extensible Coverage Path Planning library

--- a/src/fields2cover/path_planning/dubins_curves_cc.cpp
+++ b/src/fields2cover/path_planning/dubins_curves_cc.cpp
@@ -76,4 +76,8 @@ F2CPath DubinsCurvesCC::createConstrainedTurn(const F2CRobot& robot,
   }
 }
 
+bool DubinsCurvesCC::hasContinuousCurvature() const {
+  return true;
+}
+
 }  // namespace f2c::pp

--- a/src/fields2cover/path_planning/reeds_shepp_curves_hc.cpp
+++ b/src/fields2cover/path_planning/reeds_shepp_curves_hc.cpp
@@ -35,5 +35,9 @@ F2CPath ReedsSheppCurvesHC::createSimpleTurn(const F2CRobot& robot,
       robot.getTurnVel());
 }
 
+bool ReedsSheppCurvesHC::hasContinuousCurvature() const {
+  return true;
+}
+
 }  // namespace f2c::pp
 

--- a/src/fields2cover/path_planning/turning_base.cpp
+++ b/src/fields2cover/path_planning/turning_base.cpp
@@ -111,6 +111,10 @@ bool TurningBase::isTurnValid(const types::Path& path,
     (fabs(p_end.getY()) < max_dist);
 }
 
+bool TurningBase::hasContinuousCurvature() const {
+  return false;
+}
+
 double TurningBase::getDiscretization() const {
   return this->discretization;
 }

--- a/src/fields2cover/types/Route.cpp
+++ b/src/fields2cover/types/Route.cpp
@@ -180,6 +180,36 @@ bool Route::isEmpty() const {
   return v_swaths_.empty() && connections_.empty();
 }
 
+void Route::reverse() {
+  // Connections are stored before the swaths they lead into, and the last one
+  // is optional. Adding it keeps the connections paired with the right swaths
+  // once the order is flipped.
+  if (this->sizeConnections() == this->sizeVectorSwaths()) {
+    this->connections_.emplace_back();
+  }
+  std::reverse(this->connections_.begin(), this->connections_.end());
+  for (auto&& c : this->connections_) {
+    MultiPoint reversed;
+    for (size_t i = c.size(); i > 0; --i) {
+      reversed.addPoint(c.getGeometry(i - 1));
+    }
+    c = reversed;
+  }
+
+  if (this->sizeConnections() > this->sizeVectorSwaths() &&
+      this->connections_.back().isEmpty()) {
+    this->connections_.pop_back();
+  }
+
+  std::reverse(this->v_swaths_.begin(), this->v_swaths_.end());
+  for (auto&& s : this->v_swaths_) {
+    s.reverse();
+    for (auto&& swath : s) {
+      swath.reverse();
+    }
+  }
+}
+
 Route Route::clone() const {
   Route new_r;
   for (auto&& s : this->v_swaths_) {

--- a/tests/cpp/types/Route_test.cpp
+++ b/tests/cpp/types/Route_test.cpp
@@ -87,4 +87,68 @@ TEST(fields2cover_types_route, init) {
 
 }
 
+namespace {
+
+F2CRoute createRouteToReverse() {
+  F2CRoute route;
+  route.addConnection(F2CMultiPoint({F2CPoint(-2, 0), F2CPoint(0, 0)}));
+  F2CSwaths swaths1;
+  swaths1.emplace_back(F2CLineString({F2CPoint(0, 0), F2CPoint(2, 0)}), 1);
+  route.addSwaths(swaths1);
+  route.addConnection(F2CMultiPoint({F2CPoint(2, 0), F2CPoint(2, 1)}));
+  F2CSwaths swaths2;
+  swaths2.emplace_back(F2CLineString({F2CPoint(2, 1), F2CPoint(0, 1)}), 1);
+  swaths2.emplace_back(F2CLineString({F2CPoint(0, 2), F2CPoint(2, 2)}), 1);
+  route.addSwaths(swaths2);
+  return route;
+}
+
+void expectSameLine(const F2CLineString& a, const F2CLineString& b) {
+  ASSERT_EQ(a.size(), b.size());
+  for (size_t i = 0; i < a.size(); ++i) {
+    EXPECT_EQ(a[i], b[i]);
+  }
+}
+
+}  // namespace
+
+TEST(fields2cover_types_route, reverse) {
+  F2CRoute route = createRouteToReverse();
+  const F2CPoint start = route.startPoint();
+  const F2CPoint end = route.endPoint();
+  const double length = route.length();
+  const F2CLineString line = route.asLineString();
+  const size_t n_connections = route.sizeConnections();
+
+  route.reverse();
+  EXPECT_EQ(route.startPoint(), end);
+  EXPECT_EQ(route.endPoint(), start);
+  EXPECT_NEAR(route.length(), length, 1e-7);
+
+  // Swaths are driven in the opposite direction too.
+  EXPECT_EQ(route.getSwaths(0)[0].startPoint(), F2CPoint(2, 2));
+  EXPECT_EQ(route.getSwaths(0)[0].endPoint(), F2CPoint(0, 2));
+
+  route.reverse();
+  expectSameLine(route.asLineString(), line);
+  EXPECT_EQ(route.sizeConnections(), n_connections);
+}
+
+TEST(fields2cover_types_route, reverseWithLastConnection) {
+  F2CRoute route = createRouteToReverse();
+  route.addConnection(F2CMultiPoint({F2CPoint(2, 2), F2CPoint(4, 2)}));
+  const F2CPoint start = route.startPoint();
+  const F2CPoint end = route.endPoint();
+  const F2CLineString line = route.asLineString();
+  const size_t n_connections = route.sizeConnections();
+
+  route.reverse();
+  EXPECT_EQ(route.startPoint(), end);
+  EXPECT_EQ(route.endPoint(), start);
+  EXPECT_EQ(route.sizeConnections(), n_connections);
+
+  route.reverse();
+  expectSameLine(route.asLineString(), line);
+}
+
 


### PR DESCRIPTION
### Motivation

Three pieces of information the library already has internally but does not offer to
callers: the radius a continuous-curvature turn sweeps, whether a turn planner keeps the
curvature continuous, and reversing a route.

Each one currently forces the caller into something worse — duplicating a formula it
cannot compute exactly, branching on concrete planner types, or rebuilding a `Route` by
hand. All three are additive, none changes behavior, and each is one commit.

They are prerequisites for the `planPathForConnection` fix (#231), but they are gaps in
their own right, and sending them first keeps that fix reviewable as a single concern.

### 1. Make `PathPlanning::getSmoothTurningRadius` public

Moved the declaration from the private block to the public one. Body untouched.

The value cannot be computed outside the library: the function calls `end_of_clothoid`
from `steering_functions/utilities/utilities.hpp`, and those headers are not part of the
install (only `fields2cover` and `matplot` land in the install prefix). We currently
approximate it downstream with a different formula, which drifts from what F2C itself
plans.

### 2. Add `TurningBase::hasContinuousCurvature()`

Added `virtual bool hasContinuousCurvature() const` returning `false`, overridden to
`true` in `DubinsCurvesCC` and `ReedsSheppCurvesHC`.

Choosing the radius to round a corner with depends on whether the turn planner ramps the
curvature or steps it. A caller holding a `TurningBase&` has no way to ask, so it would
have to branch on the concrete type and silently pick wrong for any planner added later.

Querying the robot instead is not equivalent: `tutorials/6_path_planning.cpp` drives
plain `DubinsCurves` with a robot that has `MaxDiffCurv` set. Continuity is a property of
the planner, not of the robot.

Left non-pure so that `TurningBase` subclasses outside this repo keep compiling.

### 3. Add `Route::reverse()`

Reverses the group order, each `Swaths`, each `Swath`, and the point order of each
connection.

`Swath::reverse()` and `Swaths::reverse()` already exist — `Route` was the missing one,
so anything that needs a route driven backwards has to rebuild it by hand.

One detail worth a look during review: connections are stored *before* the swaths they
lead into and the trailing one is optional, so `connections_.size()` is either
`v_swaths_.size()` or one more. Reversing both vectors on their own shifts the
connections by one whenever there is no trailing connection. The implementation appends
an empty connection first when needed and drops a trailing empty one afterwards, so
reversing twice returns the exact original, connection count included.

Two smaller things: `Swaths::reverse()` only reverses the swath order and not the driving
direction of each swath, so `Swath::reverse()` is called per swath as well; and
`MultiPoint` has no `reversePoints()` (unlike `LineString`/`LinearRing`), so connections
are rebuilt.

### Note

Adding a virtual method changes the vtable layout, so this is an ABI break.
