### PR TITLE
Follow connection polylines instead of cutting across them

### DIFF
--- a/include/fields2cover/path_planning/path_planning.h
+++ b/include/fields2cover/path_planning/path_planning.h
@@ -43,13 +43,6 @@ class PathPlanning {
   /// Radius swept by a turn with continuous curvature. Wider than the minimum
   /// turning radius, as the clothoid ramps spend part of the deflection.
   static double getSmoothTurningRadius(const F2CRobot& robot);
-
- private:
-  static std::vector<std::pair<F2CPoint, double>> simplifyConnection(
-      const F2CRobot& robot,
-      const F2CPoint& p1, double ang1,
-      const F2CMultiPoint& mp,
-      const F2CPoint& p2, double ang2);
 };
 
 }  // namespace f2c::pp

--- a/include/fields2cover/types/LineString.h
+++ b/include/fields2cover/types/LineString.h
@@ -38,6 +38,9 @@ struct LineString : public Geometries<LineString, OGRLineString, wkbLineString,
   void reversePoints();
   size_t size() const;
 
+  /// Copy of the points, in order.
+  std::vector<Point> toVectorPoint() const;
+
   void getGeometry(size_t i, Point& point);
   void getGeometry(size_t i, Point& point) const;
   Point getGeometry(size_t i);

--- a/include/fields2cover/types/MultiPoint.h
+++ b/include/fields2cover/types/MultiPoint.h
@@ -25,6 +25,9 @@ struct MultiPoint :
 
   size_t size() const;
 
+  /// Copy of the points, in order.
+  std::vector<Point> toVectorPoint() const;
+
   void getGeometry(size_t i, Point& point);
 
   void getGeometry(size_t i, Point& point) const;

--- a/include/fields2cover/types/Path.h
+++ b/include/fields2cover/types/Path.h
@@ -75,6 +75,7 @@ struct Path {
   double length(void) const;
 
   void appendSwath(const Swath& swath, double cruise_speed);
+  void appendSwath(const Swath& swath, double cruise_speed, PathSectionType type);
 
   PathState at(double t) const;
   Point atStart() const;

--- a/include/fields2cover/types/Path.h
+++ b/include/fields2cover/types/Path.h
@@ -77,6 +77,14 @@ struct Path {
   void appendSwath(const Swath& swath, double cruise_speed);
   void appendSwath(const Swath& swath, double cruise_speed, PathSectionType type);
 
+  /// Append a straight leg from one point to another as a single state.
+  /// Legs shorter than 1e-6 are skipped, as they carry no direction.
+  void appendStraight(const Point& start, const Point& end,
+      double cruise_speed, PathSectionType type);
+
+  /// Furthest any state of this path lies from the given line.
+  double maxDistanceTo(const LineString& line) const;
+
   PathState at(double t) const;
   Point atStart() const;
   Point atEnd() const;

--- a/include/fields2cover/types/Point.h
+++ b/include/fields2cover/types/Point.h
@@ -73,6 +73,9 @@ struct Point : public Geometry<OGRPoint, wkbPoint> {
   static double getAngleFromPoints(
       const Point& p1, const Point& p2, const Point& p3);
   Point getPointFromAngle(double angle, double dist) const;
+  /// Point at a distance along the ray towards another point.
+  /// Returns this point if both coincide, as no direction is defined then.
+  Point getPointAlong(const Point& to, double dist) const;
 
   Point rotateFromPoint(double angle, const Point& p_r) const;
 

--- a/include/fields2cover/types/Robot.h
+++ b/include/fields2cover/types/Robot.h
@@ -62,51 +62,39 @@ struct Robot {
   /// Radius a turn deflecting `sweep` radians is driven at
   double getTurnRadius(double sweep, bool continuous) const;
 
-  /// How far rounding a corner may leave its track [m]
   double getMaxCornerCut() const;
   void setMaxCornerCut(double);
 
-  /// Below this deviation from the straight hop, a connection is driven direct [m]
   double getDirectHopMaxDev() const;
   void setDirectHopMaxDev(double);
 
-  /// Below this hop, a reversal is a u-turn rather than a detour [m]
   double getUturnMaxHop() const;
   void setUturnMaxHop(double);
 
-  /// Points this close to the chord they would round are dropped [m]
   double getTrackSimplifyTol() const;
   void setTrackSimplifyTol(double);
 
-  /// Heading difference between legs that reads as doubling back [rad]
   double getReversalSweep() const;
   void setReversalSweep(double);
 
-  /// Turning this much past the corner's deflection is a loop or an S [rad]
   double getTurnSlack() const;
   void setTurnSlack(double);
 
-  /// Corners deflecting less than this are driven straight through [rad]
   double getMinSweep() const;
   void setMinSweep(double);
 
-  /// Share of a leg a corner may use, the rest left to the corner beyond it
   double getLegShare() const;
   void setLegShare(double);
 
-  /// Room for a continuous turn's clothoid lead-in, in tangent lengths
   double getRadiusMargin() const;
   void setRadiusMargin(double);
 
-  /// Approach a shallow corner keeps, in turn radii
   double getMinBackoffRadii() const;
   void setMinBackoffRadii(double);
 
-  /// How far back a u-turn may start, in turn radii
   double getUturnReachRadii() const;
   void setUturnReachRadii(double);
 
-  /// Most corners folded into a single maneuver
   size_t getMaxCornerSpan() const;
   void setMaxCornerSpan(size_t);
 
@@ -130,22 +118,34 @@ struct Robot {
   /// Velocity of the robot when doing turns. If not set, cruise_speed_ is used
   std::optional<double> turn_vel_;
 
-  /// If not set, derived from the turning radius and the operation width
+  /// How far rounding a corner may leave its track. If not set, the wider of
+  /// the turning radius and half the operation width, capped at the width.
   std::optional<double> max_corner_cut_;
-  /// If not set, a quarter of the operation width
+  /// Below this deviation from the straight hop, a connection is driven
+  /// direct. If not set, a quarter of the operation width.
   std::optional<double> direct_hop_max_dev_;
-  /// If not set, three operation widths
+  /// Below this hop, a reversal is a u-turn rather than a detour to follow.
+  /// If not set, three operation widths.
   std::optional<double> uturn_max_hop_;
-  /// If not set, a tenth of the operation width
+  /// Points this close to the chord they would round are dropped before a
+  /// connection's corners are planned. If not set, a tenth of the width.
   std::optional<double> track_simplify_tol_;
 
-  double reversal_sweep_ {2.0};      // [rad]
-  double turn_slack_ {1.0};          // [rad]
-  double min_sweep_ {0.05};          // [rad]
+  /// Heading difference between two legs that reads as doubling back
+  double reversal_sweep_ {2.0};  // [rad]
+  /// Turning this much past a corner's deflection is a loop or an S, refused
+  double turn_slack_ {1.0};  // [rad]
+  /// Corners deflecting less than this are driven straight through
+  double min_sweep_ {0.05};  // [rad]
+  /// Share of a leg a corner may use, the rest left to the corner beyond it
   double leg_share_ {0.5};
+  /// Room for a continuous turn's clothoid lead-in, in tangent lengths
   double radius_margin_ {1.2};
+  /// Approach a shallow corner keeps even where its tangent collapses, in turn radii
   double min_backoff_radii_ {0.5};
+  /// How far back a u-turn may start, in turn radii
   double uturn_reach_radii_ {4.0};
+  /// Most corners folded into a single maneuver
   size_t max_corner_span_ {3};
 };
 

--- a/include/fields2cover/types/Robot.h
+++ b/include/fields2cover/types/Robot.h
@@ -57,6 +57,59 @@ struct Robot {
   double getMaxDiffCurv() const;
   void setMaxDiffCurv(double);
 
+  /// Radius swept by a turn with continuous curvature, wider than the minimum
+  double getSmoothTurningRadius() const;
+  /// Radius a turn deflecting `sweep` radians is driven at
+  double getTurnRadius(double sweep, bool continuous) const;
+
+  /// How far rounding a corner may leave its track [m]
+  double getMaxCornerCut() const;
+  void setMaxCornerCut(double);
+
+  /// Below this deviation from the straight hop, a connection is driven direct [m]
+  double getDirectHopMaxDev() const;
+  void setDirectHopMaxDev(double);
+
+  /// Below this hop, a reversal is a u-turn rather than a detour [m]
+  double getUturnMaxHop() const;
+  void setUturnMaxHop(double);
+
+  /// Points this close to the chord they would round are dropped [m]
+  double getTrackSimplifyTol() const;
+  void setTrackSimplifyTol(double);
+
+  /// Heading difference between legs that reads as doubling back [rad]
+  double getReversalSweep() const;
+  void setReversalSweep(double);
+
+  /// Turning this much past the corner's deflection is a loop or an S [rad]
+  double getTurnSlack() const;
+  void setTurnSlack(double);
+
+  /// Corners deflecting less than this are driven straight through [rad]
+  double getMinSweep() const;
+  void setMinSweep(double);
+
+  /// Share of a leg a corner may use, the rest left to the corner beyond it
+  double getLegShare() const;
+  void setLegShare(double);
+
+  /// Room for a continuous turn's clothoid lead-in, in tangent lengths
+  double getRadiusMargin() const;
+  void setRadiusMargin(double);
+
+  /// Approach a shallow corner keeps, in turn radii
+  double getMinBackoffRadii() const;
+  void setMinBackoffRadii(double);
+
+  /// How far back a u-turn may start, in turn radii
+  double getUturnReachRadii() const;
+  void setUturnReachRadii(double);
+
+  /// Most corners folded into a single maneuver
+  size_t getMaxCornerSpan() const;
+  void setMaxCornerSpan(size_t);
+
  private:
   std::string name_;
 
@@ -76,6 +129,24 @@ struct Robot {
 
   /// Velocity of the robot when doing turns. If not set, cruise_speed_ is used
   std::optional<double> turn_vel_;
+
+  /// If not set, derived from the turning radius and the operation width
+  std::optional<double> max_corner_cut_;
+  /// If not set, a quarter of the operation width
+  std::optional<double> direct_hop_max_dev_;
+  /// If not set, three operation widths
+  std::optional<double> uturn_max_hop_;
+  /// If not set, a tenth of the operation width
+  std::optional<double> track_simplify_tol_;
+
+  double reversal_sweep_ {2.0};      // [rad]
+  double turn_slack_ {1.0};          // [rad]
+  double min_sweep_ {0.05};          // [rad]
+  double leg_share_ {0.5};
+  double radius_margin_ {1.2};
+  double min_backoff_radii_ {0.5};
+  double uturn_reach_radii_ {4.0};
+  size_t max_corner_span_ {3};
 };
 
 }  // namespace f2c::types

--- a/src/fields2cover/path_planning/path_planning.cpp
+++ b/src/fields2cover/path_planning/path_planning.cpp
@@ -4,10 +4,308 @@
 //                        BSD-3 License
 //=============================================================================
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <vector>
 #include <steering_functions/utilities/utilities.hpp>
 #include "fields2cover/path_planning/path_planning.h"
 
 namespace f2c::pp {
+
+namespace {
+
+// Fractions of the operation width, unless noted otherwise.
+constexpr double kLegShare = 0.5;         // a leg is split evenly between its two corners
+constexpr double kMinSweep = 0.05;        // corners under ~3deg are driven straight through
+constexpr double kRadiusMargin = 1.2;     // room for the clothoid lead-in of a CC turn
+constexpr double kMinBackoffRadii = 0.5;  // shallow corners still get a workable approach
+constexpr double kTurnSlack = 1.0;        // turning past this much extra is a loop or an S
+constexpr double kReversalSweep = 2.0;    // legs this far apart in heading double back
+constexpr double kUturnHopWidths = 3.0;   // a u-turn between neighbours spans about one
+constexpr double kUturnReachRadii = 4.0;  // how far back a u-turn may start, in radii
+constexpr size_t kMaxSpan = 3;            // a spur, the corner it leads to, and a spur out
+
+// Below this deviation from the straight hop, a connection is driven direct.
+constexpr double kDirectHopDev = 0.25;
+// Points this close to the chord they'd round are dropped before rounding.
+constexpr double kSimplifyTol = 0.1;
+
+// cut_tol is the wider of these two -- see cutTolerance() for why.
+constexpr double kCutTolWidths = 0.5;
+constexpr double kCutTolRadii = 1.0;
+
+// A leg runs along the connection's own track, driven at cruise speed.
+void addStraight(F2CPath& path, const F2CRobot& robot,
+    const F2CPoint& a, const F2CPoint& b) {
+  const double len = a.distance(b);
+  if (len < 1e-6) {
+    return;
+  }
+  F2CPathState s;
+  s.point = a;
+  s.angle = (b - a).getAngleFromPoint();
+  s.len = len;
+  s.dir = f2c::types::PathDirection::FORWARD;
+  s.type = f2c::types::PathSectionType::HL_SWATH;
+  s.velocity = robot.getCruiseVel();
+  path.addState(s);
+}
+
+// Radius the turn actually sweeps, which is what the approach to a corner has
+// to be sized from. Two effects widen it past the minimum turning radius, and
+// they dominate at opposite ends of the range:
+//
+//   - the clothoid ramps spend part of the deflection, so a turn that reaches
+//     full curvature sweeps wider than 1/kappa (getSmoothTurningRadius);
+//   - a shallow corner never reaches full curvature at all, peaking at
+//     sqrt(rate * sweep), so the gentler the corner the wider it sweeps.
+//
+// Taking the larger keeps the approach honest at both ends. Dropping the
+// deflection term lets a shallow corner be planned from a radius it never
+// drives, which starts the turn too late and overlaps the leg it came in on.
+double cornerRadius(const F2CRobot& robot, double sweep, bool continuous) {
+  const double min_radius = robot.getMinTurningRadius();
+  const double rate = robot.getMaxDiffCurv();
+  if (!continuous || rate <= 0.0) {
+    return min_radius;
+  }
+  double radius = std::max(min_radius, PathPlanning::getSmoothTurningRadius(robot));
+  if (sweep > 0.0) {
+    radius = std::max(radius, 1.0 / std::sqrt(rate * sweep));
+  }
+  return radius;
+}
+
+// How far rounding a corner may leave the track. Floored in turning radii,
+// capped at the operation width: a compact implement (radius close to its own
+// width) still gets room for a fillet, but a wide-turning one doesn't get a
+// tolerance loose enough to cut corners it should instead leave sharp.
+double cutTolerance(const F2CRobot& robot) {
+  return std::max(
+      std::min(kCutTolRadii * robot.getMinTurningRadius(), robot.getCovWidth()),
+      kCutTolWidths * robot.getCovWidth());
+}
+
+// Point `dist` along the ray from `from` to `to`; `from` itself if they coincide.
+F2CPoint pointAlong(const F2CPoint& from, const F2CPoint& to, double dist) {
+  if (from.distance(to) < 1e-9) {
+    return from;
+  }
+  return from.getPointFromAngle((to - from).getAngleFromPoint(), dist);
+}
+
+// Furthest any state of `arc` strays from the polyline it stands in for.
+double deviationFromTrack(const F2CPath& arc, const std::vector<F2CPoint>& track) {
+  double worst = 0.0;
+  for (auto&& s : arc.getStates()) {
+    double nearest = std::numeric_limits<double>::max();
+    for (size_t k = 0; k + 1 < track.size(); ++k) {
+      nearest = std::min(nearest, s.point.distance(F2CLineString(track[k], track[k + 1])));
+    }
+    worst = std::max(worst, nearest);
+  }
+  return worst;
+}
+
+// Follow `poly`: straight runs as they are, corners through the turn planner.
+// `start_angle`/`end_angle` are the swath headings at either end, unset if
+// there's none -- the track's own first/last leg is often a spur off the
+// border graph the robot never drives (see PR-4, B.3). Returns the count of
+// corners left sharp because no maneuver fit within `cut_tol` of the track.
+size_t appendRoundedTrack(
+    F2CPath& path, const std::vector<F2CPoint>& poly, const F2CRobot& robot,
+    TurningBase& turn, double cut_tol, bool continuous,
+    const std::optional<double>& start_angle, const std::optional<double>& end_angle) {
+  const double radius = robot.getMinTurningRadius();
+  const double op_width = robot.getCovWidth();
+  const size_t n = poly.size();
+  const auto legAngle = [&poly](size_t a, size_t b) {
+      return (poly[b] - poly[a]).getAngleFromPoint();
+    };
+
+  // Deflection at each corner, which is what sizes the maneuver through it.
+  std::vector<double> sweeps(n, 0.0);
+  for (size_t k = 1; k + 1 < n; ++k) {
+    sweeps[k] = F2CPoint::getAngleDiffAbs(legAngle(k - 1, k), legAngle(k, k + 1));
+  }
+  if (start_angle && n > 1) {
+    sweeps.front() = F2CPoint::getAngleDiffAbs(*start_angle, legAngle(0, 1));
+  }
+  if (end_angle && n > 1) {
+    sweeps.back() = F2CPoint::getAngleDiffAbs(legAngle(n - 2, n - 1), *end_angle);
+  }
+
+  size_t sharp = 0;
+  F2CPoint cursor = poly.front();
+  size_t i = 0;
+  while (i < n) {
+    if (sweeps[i] < kMinSweep) {
+      addStraight(path, robot, cursor, poly[i]);
+      cursor = poly[i];
+      ++i;
+      continue;
+    }
+
+    // Corners too close together to round one at a time fold into one span.
+    size_t min_span = 1;
+    while (i + min_span < n && min_span < kMaxSpan &&
+        sweeps[i + min_span] >= kMinSweep &&
+        poly[i + min_span - 1].distance(poly[i + min_span]) <
+            2.0 * kRadiusMargin * radius) {
+      ++min_span;
+    }
+
+    bool rounded = false;
+    // Widening out from there, because a shorter span cuts less corner.
+    for (size_t span = min_span; span <= kMaxSpan && i + span <= n && !rounded; ++span) {
+      const size_t j = i + span - 1;  // last corner taken in one go
+      // At either end the pose is pinned to the swath, not slid along a leg.
+      const bool pin_in = (i == 0);
+      const bool pin_out = (j + 1 == n);
+      if (pin_out && !end_angle) {
+        break;
+      }
+      const F2CPoint& first = poly[i];
+      const F2CPoint& last_corner = poly[j];
+      const F2CPoint& after = pin_out ? poly[j] : poly[j + 1];
+
+      // Total turning sizes the maneuver's length; net deflection (which can
+      // be smaller, e.g. on an S where corners cancel) sizes its geometry.
+      double total = 0.0;
+      for (size_t k = i; k <= j; ++k) {
+        total += sweeps[k];
+      }
+      const double in_angle = pin_in ?
+          *start_angle : (first - cursor).getAngleFromPoint();
+      const double out_angle = pin_out ?
+          *end_angle : (after - last_corner).getAngleFromPoint();
+      const double net = F2CPoint::getAngleDiffAbs(in_angle, out_angle);
+
+      const bool tail = (j + 2 == n) && sweeps[n - 1] < kMinSweep;
+      const double back_room = pin_in ? 0.0 : cursor.distance(first);
+      const double fwd_room = pin_out ? 0.0 :
+          (tail ? 1.0 : kLegShare) * last_corner.distance(after);
+      const double room = pin_in ? fwd_room : (pin_out ? back_room :
+          std::min(back_room, fwd_room));
+
+      // A short reversal is a u-turn (swings past the vertices into the
+      // headland), not a corner to fillet; a long one is a detour to follow.
+      const double hop = first.distance(last_corner);
+      const bool uturn = net > kReversalSweep && hop < kUturnHopWidths * op_width;
+
+      // Offset of the outgoing leg from the entry heading's line.
+      const double sep = std::fabs(
+          std::cos(in_angle) * (after.getY() - first.getY()) -
+          std::sin(in_angle) * (after.getX() - first.getX()));
+
+      double lo = kMinBackoffRadii * cornerRadius(robot, net, continuous);
+      double hi = room;
+      if (!uturn) {
+        if (net > M_PI - 1e-3) {
+          continue;  // reversal too wide to be anything but a detour
+        }
+        const double tangent_margin = continuous ? kRadiusMargin : 1.0;
+        lo = std::max(
+            tangent_margin * cornerRadius(robot, net, continuous) * std::tan(0.5 * net), lo);
+        hi = std::min(hi, cut_tol / std::max(std::tan(0.25 * net), 1e-6));
+      }
+      // On a jog net cancels to ~0 and the tan(net/4) bound with it; fall
+      // back to bounding the offset by the ground the maneuver makes up.
+      // At a pinned end taking a single corner there is no outgoing leg to
+      // measure that against -- `after` is the corner itself -- so the bound
+      // would collapse to zero and refuse a corner the tangent bound allows.
+      if (!pin_out || j > i) {
+        hi = std::min(hi, sep + kRadiusMargin * (1.0 + total) * radius);
+      }
+      if (lo > hi) {
+        continue;
+      }
+
+      // A fillet meets both legs the same distance out; a u-turn instead
+      // takes whatever room each leg has, to turn a cusp into a drivable arc.
+      double in_reach = hi;
+      double out_reach = hi;
+      if (uturn) {
+        const double reach = kUturnReachRadii * cornerRadius(robot, net, continuous);
+        in_reach = std::max(lo, std::min(back_room, reach));
+        out_reach = std::max(lo, std::min(fwd_room, reach));
+      }
+      if (pin_in) {
+        in_reach = 0.0;
+      }
+      if (pin_out) {
+        out_reach = 0.0;
+      }
+
+      // Widen the offset until the planner accepts; a fillet is tried
+      // tightest first (cuts least), a u-turn widest. Sampled finely because
+      // the planner can refuse one specific offset for no geometric reason,
+      // and jumping straight to a much wider one would cut more than needed.
+      const std::array<double, 6> fracs =
+          uturn ?
+          std::array<double, 6>{1.0, 0.75, 0.5, 0.25, 0.1, 0.0} :
+          std::array<double, 6>{0.0, 0.1, 0.25, 0.5, 0.75, 1.0};
+      for (const double frac : fracs) {
+        const double back_off = pin_in ? 0.0 : lo + frac * (in_reach - lo);
+        const double fwd_off = pin_out ? 0.0 : lo + frac * (out_reach - lo);
+        const F2CPoint entry = pointAlong(first, cursor, back_off);
+        const F2CPoint exit = pointAlong(last_corner, after, fwd_off);
+        F2CPath arc = turn.createTurn(robot, entry, in_angle, exit, out_angle);
+        if (arc.size() == 0) {
+          continue;
+        }
+
+        // A feasible pose pair can still come back as a loop, or as an S that
+        // doubles back before settling. Both turn far more than the corner
+        // asks for, which length alone measures only indirectly -- a loop's
+        // extra 2*pi is cheap at a small radius and hides inside a length
+        // budget. Compare the turning itself.
+        double turned = 0.0;
+        for (size_t k = 1; k < arc.size(); ++k) {
+          turned += F2CPoint::getAngleDiffAbs(arc[k].angle, arc[k - 1].angle);
+        }
+        // A u-turn earns its teardrop; anything else should turn once.
+        if (turned > total + (uturn ? M_PI : kTurnSlack)) {
+          continue;
+        }
+
+        std::vector<F2CPoint> track{entry};
+        for (size_t k = i; k <= j; ++k) {
+          track.push_back(poly[k]);
+        }
+        track.push_back(exit);
+        // A u-turn is allowed the corridor plus the diameter it swings past.
+        const double dev = deviationFromTrack(arc, track);
+        const double dev_max = uturn ?
+            cut_tol + 2.0 * cornerRadius(robot, net, continuous) : cut_tol;
+        if (dev > dev_max) {
+          continue;
+        }
+
+        addStraight(path, robot, cursor, entry);
+        path += arc;  // as the planner returned it, reverse legs included
+        cursor = exit;
+        i = j + 1;
+        rounded = true;
+        break;
+      }
+    }
+
+    if (!rounded) {
+      ++sharp;
+      addStraight(path, robot, cursor, poly[i]);
+      cursor = poly[i];
+      ++i;
+    }
+  }
+  addStraight(path, robot, cursor, poly.back());
+  return sharp;
+}
+
+}  // namespace
 
 F2CPath PathPlanning::planPath(const F2CRobot& robot,
     const F2CRoute& route, TurningBase& turn) {
@@ -77,19 +375,45 @@ F2CPath PathPlanning::planPathForConnection(const F2CRobot& robot,
     const F2CMultiPoint& mp,
     const F2CPoint& p2, double ang2,
     TurningBase& turn) {
-  auto v_con = simplifyConnection(robot,
-      p1, ang1, mp, p2, ang2);
+  std::vector<F2CPoint> pts{p1};
+  for (size_t i = 0; i < mp.size(); ++i) {
+    pts.push_back(mp[i]);
+  }
+  pts.push_back(p2);
+
+  // A track close to the straight hop isn't a detour, so drive it direct; a
+  // short-hop reversal is the same call, since no fillet can round a u-turn.
+  double max_dev = 0.0;
+  for (size_t i = 1; i + 1 < pts.size(); ++i) {
+    max_dev = std::max(max_dev, pts[i].distance(F2CLineString(p1, p2)));
+  }
+  const double op_width = robot.getCovWidth();
+  bool direct = max_dev < kDirectHopDev * op_width;
+  if (!direct) {
+    const double reversal = F2CPoint::getAngleDiffAbs(ang1, ang2);
+    const double hop = p1.distance(p2);
+    direct = reversal > kReversalSweep && hop < kUturnHopWidths * op_width;
+  }
+  if (direct) {
+    return turn.createTurn(robot, p1, ang1, p2, ang2);
+  }
+
+  // Otherwise follow the detour, rounding its corners, rather than cutting
+  // across ground the route deliberately routed around.
+  F2CLineString simplified = F2CLineString(pts).simplify(kSimplifyTol * op_width);
+  std::vector<F2CPoint> poly;
+  for (size_t i = 0; i < simplified.size(); ++i) {
+    poly.push_back(simplified[i]);
+  }
+  if (poly.size() < 2) {
+    return {};
+  }
 
   F2CPath path;
-  for (int i = 1; i < v_con.size(); ++i) {
-    path += turn.createTurn(robot,
-        v_con[i-1].first, v_con[i-1].second,
-        v_con[i].first, v_con[i].second);
-  }
+  appendRoundedTrack(path, poly, robot, turn, cutTolerance(robot),
+      turn.hasContinuousCurvature(), ang1, ang2);
   return path;
 }
-
-
 
 double PathPlanning::getSmoothTurningRadius(const F2CRobot& robot) {
   double x, y, ang, k;
@@ -99,62 +423,6 @@ double PathPlanning::getSmoothTurningRadius(const F2CRobot& robot) {
   double xi = x - sin(ang) / robot.getMaxCurv();
   double yi = y + cos(ang) / robot.getMaxCurv();
   return sqrt(xi*xi + yi*yi);
-}
-
-std::vector<std::pair<F2CPoint, double>> PathPlanning::simplifyConnection(
-    const F2CRobot& robot,
-    const F2CPoint& p1, double ang1,
-    const F2CMultiPoint& mp,
-    const F2CPoint& p2, double ang2) {
-  const double safe_dist = getSmoothTurningRadius(robot);
-  std::vector<std::pair<F2CPoint, double>> path;
-  path.emplace_back(p1, ang1);
-
-  if (p1.distance(p2) < 6.0 * safe_dist || mp.size() < 2) {
-    path.emplace_back(p2, ang2);
-    return path;
-  }
-
-  std::vector<F2CPoint> vp;
-  for (int i = 1; i < mp.size() - 1; ++i) {
-    double ang_in  = (mp[i] - mp[i-1]).getAngleFromPoint();
-    double ang_out = (mp[i+1] - mp[i]).getAngleFromPoint();
-    if (fabs(ang_in - ang_out) > 0.1) {
-      vp.emplace_back(mp[i]);
-    }
-  }
-
-  if (vp.size() < 2) {
-    path.emplace_back(p2, ang2);
-    return path;
-  }
-
-  for (int i = 1; i < vp.size() - 1; ++i) {
-    double dist_in  = vp[i].distance(vp[i-1]);
-    double dist_out  = vp[i].distance(vp[i+1]);
-    if (dist_in == 0.0 || dist_out == 0.0) {
-      continue;
-    }
-    double d_in  = min(0.5 * dist_in,  safe_dist);
-    double d_out  = min(0.5 * dist_out,  safe_dist);
-    F2CPoint p_in =  (vp[i-1] - vp[i]) * (d_in  / dist_in)  + vp[i];
-    F2CPoint p_out = (vp[i+1] - vp[i]) * (d_out / dist_out) + vp[i];
-    if (p_in.distance(path.back().first) > 3.0 * safe_dist &&
-        p_in.distance(p1)                > 3.0 * safe_dist &&
-        p_in.distance(p2)                > 3.0 * safe_dist) {
-      double ang_in   = (vp[i  ] - vp[i-1]).getAngleFromPoint();
-      path.emplace_back(p_in, ang_in);
-    }
-    if (p_out.distance(vp[i+1]) > 3.0 * safe_dist &&
-        p_out.distance(p1)                > 3.0 * safe_dist &&
-        p_out.distance(p2)                > 3.0 * safe_dist &&
-        p_out.distance(p_in)              > 3.0 * safe_dist) {
-      double ang_out  = (vp[i+1] - vp[i]).getAngleFromPoint();
-      path.emplace_back(p_out, ang_out);
-    }
-  }
-  path.emplace_back(p2, ang2);
-  return path;
 }
 
 }  // namespace f2c::pp

--- a/src/fields2cover/path_planning/path_planning.cpp
+++ b/src/fields2cover/path_planning/path_planning.cpp
@@ -23,22 +23,16 @@ void addStraight(F2CPath& path, const F2CRobot& robot,
       f2c::types::PathSectionType::HL_SWATH);
 }
 
-// Follow `poly`: straight runs as they are, corners through the turn planner.
-// A corner only a turn cutting past `cut_tol` could round is left square.
-// `start_angle`/`end_angle` are the swath headings at either end, unset if
-// there's none -- the track's own first/last leg is often a spur off the
-// border graph the robot never drives (see PR-4, B.3).
-void appendRoundedTrack(
-    F2CPath& path, const std::vector<F2CPoint>& poly, const F2CRobot& robot,
-    TurningBase& turn, double cut_tol, bool continuous,
-    const std::optional<double>& start_angle, const std::optional<double>& end_angle) {
-  const double radius = robot.getMinTurningRadius();
+// Deflection at each corner of `poly`. The ends take the swath heading where
+// there is one: the track's own first/last leg is often a spur off the border
+// graph the robot never drives (see PR-4, B.3).
+std::vector<double> cornerSweeps(const std::vector<F2CPoint>& poly,
+    const std::optional<double>& start_angle,
+    const std::optional<double>& end_angle) {
   const size_t n = poly.size();
   const auto legAngle = [&poly](size_t a, size_t b) {
       return (poly[b] - poly[a]).getAngleFromPoint();
     };
-
-  // Deflection at each corner, which is what sizes the maneuver through it.
   std::vector<double> sweeps(n, 0.0);
   for (size_t k = 1; k + 1 < n; ++k) {
     sweeps[k] = F2CPoint::getAngleDiffAbs(legAngle(k - 1, k), legAngle(k, k + 1));
@@ -49,6 +43,184 @@ void appendRoundedTrack(
   if (end_angle && n > 1) {
     sweeps.back() = F2CPoint::getAngleDiffAbs(legAngle(n - 2, n - 1), *end_angle);
   }
+  return sweeps;
+}
+
+// Corners from `i` on that sit too close together to round one at a time:
+// rounding the first would leave the next no approach.
+size_t foldedSpan(const std::vector<F2CPoint>& poly,
+    const std::vector<double>& sweeps, size_t i, const F2CRobot& robot) {
+  const double gap = 2.0 * robot.getRadiusMargin() * robot.getMinTurningRadius();
+  size_t span = 1;
+  while (i + span < poly.size() && span < robot.getMaxCornerSpan() &&
+      sweeps[i + span] >= robot.getMinSweep() &&
+      poly[i + span - 1].distance(poly[i + span]) < gap) {
+    ++span;
+  }
+  return span;
+}
+
+// Where a maneuver through poly[i..j] may start and end, and what it must turn.
+struct Span {
+  F2CPoint first, last_corner, after;
+  double in_angle, out_angle, net, total;
+  double lo, in_reach, out_reach;
+  bool pin_in, pin_out, uturn;
+};
+
+// Size the maneuver through poly[i..j]. Unset if no turn fits between the
+// room the legs leave and the ground `cut_tol` lets it cut.
+std::optional<Span> spanGeometry(const std::vector<F2CPoint>& poly,
+    const std::vector<double>& sweeps, size_t i, size_t j,
+    const F2CPoint& cursor, const F2CRobot& robot, double cut_tol,
+    bool continuous, const std::optional<double>& start_angle,
+    const std::optional<double>& end_angle) {
+  const size_t n = poly.size();
+  const double radius = robot.getMinTurningRadius();
+  Span s;
+  // At either end the pose is pinned to the swath, not slid along a leg.
+  s.pin_in = (i == 0);
+  s.pin_out = (j + 1 == n);
+  s.first = poly[i];
+  s.last_corner = poly[j];
+  s.after = s.pin_out ? poly[j] : poly[j + 1];
+
+  // Total turning sizes the maneuver's length; net deflection (which can be
+  // smaller, e.g. on an S where corners cancel) sizes its geometry.
+  s.total = 0.0;
+  for (size_t k = i; k <= j; ++k) {
+    s.total += sweeps[k];
+  }
+  s.in_angle = s.pin_in ?
+      *start_angle : (s.first - cursor).getAngleFromPoint();
+  s.out_angle = s.pin_out ?
+      *end_angle : (s.after - s.last_corner).getAngleFromPoint();
+  s.net = F2CPoint::getAngleDiffAbs(s.in_angle, s.out_angle);
+
+  const bool tail = (j + 2 == n) && sweeps[n - 1] < robot.getMinSweep();
+  const double back_room = s.pin_in ? 0.0 : cursor.distance(s.first);
+  const double fwd_room = s.pin_out ? 0.0 :
+      (tail ? 1.0 : robot.getLegShare()) * s.last_corner.distance(s.after);
+  const double room = s.pin_in ? fwd_room : (s.pin_out ? back_room :
+      std::min(back_room, fwd_room));
+
+  // A short reversal is a u-turn (swings past the vertices into the headland),
+  // not a corner to fillet; a long one is a detour to follow.
+  const double hop = s.first.distance(s.last_corner);
+  s.uturn = s.net > robot.getReversalSweep() && hop < robot.getUturnMaxHop();
+
+  // Offset of the outgoing leg from the entry heading's line.
+  const double sep = std::fabs(
+      std::cos(s.in_angle) * (s.after.getY() - s.first.getY()) -
+      std::sin(s.in_angle) * (s.after.getX() - s.first.getX()));
+
+  const double turn_radius = robot.getTurnRadius(s.net, continuous);
+  s.lo = robot.getMinBackoffRadii() * turn_radius;
+  double hi = room;
+  if (!s.uturn) {
+    if (s.net > M_PI - 1e-3) {
+      return {};  // reversal too wide to be anything but a detour
+    }
+    const double tangent_margin = continuous ? robot.getRadiusMargin() : 1.0;
+    s.lo = std::max(tangent_margin * turn_radius * std::tan(0.5 * s.net), s.lo);
+    hi = std::min(hi, cut_tol / std::max(std::tan(0.25 * s.net), 1e-6));
+  }
+  // On a jog net cancels to ~0 and the tan(net/4) bound with it; fall back to
+  // bounding the offset by the ground the maneuver makes up. At a pinned end
+  // taking a single corner there is no outgoing leg to measure that against --
+  // `after` is the corner itself -- so the bound would collapse to zero.
+  if (!s.pin_out || j > i) {
+    hi = std::min(hi, sep + robot.getRadiusMargin() * (1.0 + s.total) * radius);
+  }
+  if (s.lo > hi) {
+    return {};
+  }
+
+  // A fillet meets both legs the same distance out; a u-turn instead takes
+  // whatever room each leg has, to turn a cusp into a drivable arc.
+  s.in_reach = hi;
+  s.out_reach = hi;
+  if (s.uturn) {
+    const double reach = robot.getUturnReachRadii() * turn_radius;
+    s.in_reach = std::max(s.lo, std::min(back_room, reach));
+    s.out_reach = std::max(s.lo, std::min(fwd_room, reach));
+  }
+  if (s.pin_in) {
+    s.in_reach = 0.0;
+  }
+  if (s.pin_out) {
+    s.out_reach = 0.0;
+  }
+  return s;
+}
+
+// A turn accepted for a span, and the points it runs between.
+struct Turn {
+  F2CPath arc;
+  F2CPoint entry, exit;
+};
+
+// Widen the offset until the planner returns a turn that rounds the span
+// rather than looping around it. Unset if none of them does.
+std::optional<Turn> planSpanTurn(const Span& s,
+    const std::vector<F2CPoint>& poly, size_t i, size_t j,
+    const F2CPoint& cursor, const F2CRobot& robot, TurningBase& turn,
+    double cut_tol, bool continuous) {
+  // A fillet is tried tightest first (it cuts least), a u-turn widest. Sampled
+  // finely because the planner can refuse one specific offset for no geometric
+  // reason, and jumping to a much wider one would cut more than needed.
+  const std::array<double, 6> fracs = s.uturn ?
+      std::array<double, 6>{1.0, 0.75, 0.5, 0.25, 0.1, 0.0} :
+      std::array<double, 6>{0.0, 0.1, 0.25, 0.5, 0.75, 1.0};
+
+  for (const double frac : fracs) {
+    Turn t;
+    const double back_off = s.pin_in ? 0.0 : s.lo + frac * (s.in_reach - s.lo);
+    const double fwd_off = s.pin_out ? 0.0 : s.lo + frac * (s.out_reach - s.lo);
+    t.entry = s.first.getPointAlong(cursor, back_off);
+    t.exit = s.last_corner.getPointAlong(s.after, fwd_off);
+    t.arc = turn.createTurn(robot, t.entry, s.in_angle, t.exit, s.out_angle);
+    if (t.arc.size() == 0) {
+      continue;
+    }
+
+    // A feasible pose pair can still come back as a loop, or as an S that
+    // doubles back before settling. Both turn far more than the span asks for,
+    // which length measures only indirectly -- a loop's extra 2*pi is cheap at
+    // a small radius. Compare the turning itself.
+    double turned = 0.0;
+    for (size_t k = 1; k < t.arc.size(); ++k) {
+      turned += F2CPoint::getAngleDiffAbs(t.arc[k].angle, t.arc[k - 1].angle);
+    }
+    // A u-turn earns its teardrop; anything else should turn once.
+    if (turned > s.total + (s.uturn ? M_PI : robot.getTurnSlack())) {
+      continue;
+    }
+
+    std::vector<F2CPoint> track{t.entry};
+    for (size_t k = i; k <= j; ++k) {
+      track.push_back(poly[k]);
+    }
+    track.push_back(t.exit);
+    // A u-turn is allowed the corridor plus the diameter it swings past.
+    const double dev_max = s.uturn ?
+        cut_tol + 2.0 * robot.getTurnRadius(s.net, continuous) : cut_tol;
+    if (t.arc.maxDistanceTo(F2CLineString(track)) > dev_max) {
+      continue;
+    }
+    return t;
+  }
+  return {};
+}
+
+// Follow `poly`: straight runs as they are, corners through the turn planner.
+// A corner only a turn cutting past `cut_tol` could round is left square.
+void appendRoundedTrack(
+    F2CPath& path, const std::vector<F2CPoint>& poly, const F2CRobot& robot,
+    TurningBase& turn, double cut_tol, bool continuous,
+    const std::optional<double>& start_angle, const std::optional<double>& end_angle) {
+  const size_t n = poly.size();
+  const std::vector<double> sweeps = cornerSweeps(poly, start_angle, end_angle);
 
   F2CPoint cursor = poly.front();
   size_t i = 0;
@@ -60,153 +232,31 @@ void appendRoundedTrack(
       continue;
     }
 
-    // Corners too close together to round one at a time fold into one span.
-    size_t min_span = 1;
-    while (i + min_span < n && min_span < robot.getMaxCornerSpan() &&
-        sweeps[i + min_span] >= robot.getMinSweep() &&
-        poly[i + min_span - 1].distance(poly[i + min_span]) <
-            2.0 * robot.getRadiusMargin() * radius) {
-      ++min_span;
-    }
-
-    bool rounded = false;
-    // Widening out from there, because a shorter span cuts less corner.
-    for (size_t span = min_span;
+    std::optional<Turn> rounded;
+    size_t last = i;
+    // Widening out from the fold, because a shorter span cuts less corner.
+    for (size_t span = foldedSpan(poly, sweeps, i, robot);
         span <= robot.getMaxCornerSpan() && i + span <= n && !rounded; ++span) {
-      const size_t j = i + span - 1;  // last corner taken in one go
-      // At either end the pose is pinned to the swath, not slid along a leg.
-      const bool pin_in = (i == 0);
-      const bool pin_out = (j + 1 == n);
-      if (pin_out && !end_angle) {
-        break;
+      const size_t j = i + span - 1;
+      if (j + 1 == n && !end_angle) {
+        break;  // an open route end holds no heading, so it is no corner
       }
-      const F2CPoint& first = poly[i];
-      const F2CPoint& last_corner = poly[j];
-      const F2CPoint& after = pin_out ? poly[j] : poly[j + 1];
-
-      // Total turning sizes the maneuver's length; net deflection (which can
-      // be smaller, e.g. on an S where corners cancel) sizes its geometry.
-      double total = 0.0;
-      for (size_t k = i; k <= j; ++k) {
-        total += sweeps[k];
-      }
-      const double in_angle = pin_in ?
-          *start_angle : (first - cursor).getAngleFromPoint();
-      const double out_angle = pin_out ?
-          *end_angle : (after - last_corner).getAngleFromPoint();
-      const double net = F2CPoint::getAngleDiffAbs(in_angle, out_angle);
-
-      const bool tail = (j + 2 == n) && sweeps[n - 1] < robot.getMinSweep();
-      const double back_room = pin_in ? 0.0 : cursor.distance(first);
-      const double fwd_room = pin_out ? 0.0 :
-          (tail ? 1.0 : robot.getLegShare()) * last_corner.distance(after);
-      const double room = pin_in ? fwd_room : (pin_out ? back_room :
-          std::min(back_room, fwd_room));
-
-      // A short reversal is a u-turn (swings past the vertices into the
-      // headland), not a corner to fillet; a long one is a detour to follow.
-      const double hop = first.distance(last_corner);
-      const bool uturn =
-          net > robot.getReversalSweep() && hop < robot.getUturnMaxHop();
-
-      // Offset of the outgoing leg from the entry heading's line.
-      const double sep = std::fabs(
-          std::cos(in_angle) * (after.getY() - first.getY()) -
-          std::sin(in_angle) * (after.getX() - first.getX()));
-
-      const double turn_radius = robot.getTurnRadius(net, continuous);
-      double lo = robot.getMinBackoffRadii() * turn_radius;
-      double hi = room;
-      if (!uturn) {
-        if (net > M_PI - 1e-3) {
-          continue;  // reversal too wide to be anything but a detour
-        }
-        const double tangent_margin = continuous ? robot.getRadiusMargin() : 1.0;
-        lo = std::max(tangent_margin * turn_radius * std::tan(0.5 * net), lo);
-        hi = std::min(hi, cut_tol / std::max(std::tan(0.25 * net), 1e-6));
-      }
-      // On a jog net cancels to ~0 and the tan(net/4) bound with it; fall
-      // back to bounding the offset by the ground the maneuver makes up.
-      // At a pinned end taking a single corner there is no outgoing leg to
-      // measure that against -- `after` is the corner itself -- so the bound
-      // would collapse to zero and refuse a corner the tangent bound allows.
-      if (!pin_out || j > i) {
-        hi = std::min(hi, sep + robot.getRadiusMargin() * (1.0 + total) * radius);
-      }
-      if (lo > hi) {
+      const std::optional<Span> s = spanGeometry(poly, sweeps, i, j, cursor,
+          robot, cut_tol, continuous, start_angle, end_angle);
+      if (!s) {
         continue;
       }
-
-      // A fillet meets both legs the same distance out; a u-turn instead
-      // takes whatever room each leg has, to turn a cusp into a drivable arc.
-      double in_reach = hi;
-      double out_reach = hi;
-      if (uturn) {
-        const double reach = robot.getUturnReachRadii() * turn_radius;
-        in_reach = std::max(lo, std::min(back_room, reach));
-        out_reach = std::max(lo, std::min(fwd_room, reach));
-      }
-      if (pin_in) {
-        in_reach = 0.0;
-      }
-      if (pin_out) {
-        out_reach = 0.0;
-      }
-
-      // Widen the offset until the planner accepts; a fillet is tried
-      // tightest first (cuts least), a u-turn widest. Sampled finely because
-      // the planner can refuse one specific offset for no geometric reason,
-      // and jumping straight to a much wider one would cut more than needed.
-      const std::array<double, 6> fracs =
-          uturn ?
-          std::array<double, 6>{1.0, 0.75, 0.5, 0.25, 0.1, 0.0} :
-          std::array<double, 6>{0.0, 0.1, 0.25, 0.5, 0.75, 1.0};
-      for (const double frac : fracs) {
-        const double back_off = pin_in ? 0.0 : lo + frac * (in_reach - lo);
-        const double fwd_off = pin_out ? 0.0 : lo + frac * (out_reach - lo);
-        const F2CPoint entry = first.getPointAlong(cursor, back_off);
-        const F2CPoint exit = last_corner.getPointAlong(after, fwd_off);
-        F2CPath arc = turn.createTurn(robot, entry, in_angle, exit, out_angle);
-        if (arc.size() == 0) {
-          continue;
-        }
-
-        // A feasible pose pair can still come back as a loop, or as an S that
-        // doubles back before settling. Both turn far more than the corner
-        // asks for, which length alone measures only indirectly -- a loop's
-        // extra 2*pi is cheap at a small radius and hides inside a length
-        // budget. Compare the turning itself.
-        double turned = 0.0;
-        for (size_t k = 1; k < arc.size(); ++k) {
-          turned += F2CPoint::getAngleDiffAbs(arc[k].angle, arc[k - 1].angle);
-        }
-        // A u-turn earns its teardrop; anything else should turn once.
-        if (turned > total + (uturn ? M_PI : robot.getTurnSlack())) {
-          continue;
-        }
-
-        std::vector<F2CPoint> track{entry};
-        for (size_t k = i; k <= j; ++k) {
-          track.push_back(poly[k]);
-        }
-        track.push_back(exit);
-        // A u-turn is allowed the corridor plus the diameter it swings past.
-        const double dev_max = uturn ?
-            cut_tol + 2.0 * turn_radius : cut_tol;
-        if (arc.maxDistanceTo(F2CLineString(track)) > dev_max) {
-          continue;
-        }
-
-        addStraight(path, robot, cursor, entry);
-        path += arc;  // as the planner returned it, reverse legs included
-        cursor = exit;
-        i = j + 1;
-        rounded = true;
-        break;
-      }
+      rounded = planSpanTurn(*s, poly, i, j, cursor, robot, turn,
+          cut_tol, continuous);
+      last = j;
     }
 
-    if (!rounded) {
+    if (rounded) {
+      addStraight(path, robot, cursor, rounded->entry);
+      path += rounded->arc;  // as returned, reverse legs included
+      cursor = rounded->exit;
+      i = last + 1;
+    } else {
       addStraight(path, robot, cursor, poly[i]);
       cursor = poly[i];
       ++i;

--- a/src/fields2cover/path_planning/path_planning.cpp
+++ b/src/fields2cover/path_planning/path_planning.cpp
@@ -16,13 +16,6 @@ namespace f2c::pp {
 
 namespace {
 
-// A leg along the connection's own track is driven as a headland pass.
-void addStraight(F2CPath& path, const F2CRobot& robot,
-    const F2CPoint& a, const F2CPoint& b) {
-  path.appendStraight(a, b, robot.getCruiseVel(),
-      f2c::types::PathSectionType::HL_SWATH);
-}
-
 // Deflection at each corner of `poly`. The ends take the swath heading where
 // there is one: the track's own first/last leg is often a spur off the border
 // graph the robot never drives (see PR-4, B.3).
@@ -226,7 +219,8 @@ void appendRoundedTrack(
   size_t i = 0;
   while (i < n) {
     if (sweeps[i] < robot.getMinSweep()) {
-      addStraight(path, robot, cursor, poly[i]);
+      path.appendStraight(cursor, poly[i], robot.getCruiseVel(),
+          f2c::types::PathSectionType::HL_SWATH);
       cursor = poly[i];
       ++i;
       continue;
@@ -252,17 +246,20 @@ void appendRoundedTrack(
     }
 
     if (rounded) {
-      addStraight(path, robot, cursor, rounded->entry);
+      path.appendStraight(cursor, rounded->entry, robot.getCruiseVel(),
+          f2c::types::PathSectionType::HL_SWATH);
       path += rounded->arc;  // as returned, reverse legs included
       cursor = rounded->exit;
       i = last + 1;
     } else {
-      addStraight(path, robot, cursor, poly[i]);
+      path.appendStraight(cursor, poly[i], robot.getCruiseVel(),
+          f2c::types::PathSectionType::HL_SWATH);
       cursor = poly[i];
       ++i;
     }
   }
-  addStraight(path, robot, cursor, poly.back());
+  path.appendStraight(cursor, poly.back(), robot.getCruiseVel(),
+      f2c::types::PathSectionType::HL_SWATH);
 }
 
 }  // namespace

--- a/src/fields2cover/path_planning/path_planning.cpp
+++ b/src/fields2cover/path_planning/path_planning.cpp
@@ -10,117 +10,29 @@
 #include <limits>
 #include <optional>
 #include <vector>
-#include <steering_functions/utilities/utilities.hpp>
 #include "fields2cover/path_planning/path_planning.h"
 
 namespace f2c::pp {
 
 namespace {
 
-// Fractions of the operation width, unless noted otherwise.
-constexpr double kLegShare = 0.5;         // a leg is split evenly between its two corners
-constexpr double kMinSweep = 0.05;        // corners under ~3deg are driven straight through
-constexpr double kRadiusMargin = 1.2;     // room for the clothoid lead-in of a CC turn
-constexpr double kMinBackoffRadii = 0.5;  // shallow corners still get a workable approach
-constexpr double kTurnSlack = 1.0;        // turning past this much extra is a loop or an S
-constexpr double kReversalSweep = 2.0;    // legs this far apart in heading double back
-constexpr double kUturnHopWidths = 3.0;   // a u-turn between neighbours spans about one
-constexpr double kUturnReachRadii = 4.0;  // how far back a u-turn may start, in radii
-constexpr size_t kMaxSpan = 3;            // a spur, the corner it leads to, and a spur out
-
-// Below this deviation from the straight hop, a connection is driven direct.
-constexpr double kDirectHopDev = 0.25;
-// Points this close to the chord they'd round are dropped before rounding.
-constexpr double kSimplifyTol = 0.1;
-
-// cut_tol is the wider of these two -- see cutTolerance() for why.
-constexpr double kCutTolWidths = 0.5;
-constexpr double kCutTolRadii = 1.0;
-
-// A leg runs along the connection's own track, driven at cruise speed.
+// A leg along the connection's own track is driven as a headland pass.
 void addStraight(F2CPath& path, const F2CRobot& robot,
     const F2CPoint& a, const F2CPoint& b) {
-  const double len = a.distance(b);
-  if (len < 1e-6) {
-    return;
-  }
-  F2CPathState s;
-  s.point = a;
-  s.angle = (b - a).getAngleFromPoint();
-  s.len = len;
-  s.dir = f2c::types::PathDirection::FORWARD;
-  s.type = f2c::types::PathSectionType::HL_SWATH;
-  s.velocity = robot.getCruiseVel();
-  path.addState(s);
-}
-
-// Radius the turn actually sweeps, which is what the approach to a corner has
-// to be sized from. Two effects widen it past the minimum turning radius, and
-// they dominate at opposite ends of the range:
-//
-//   - the clothoid ramps spend part of the deflection, so a turn that reaches
-//     full curvature sweeps wider than 1/kappa (getSmoothTurningRadius);
-//   - a shallow corner never reaches full curvature at all, peaking at
-//     sqrt(rate * sweep), so the gentler the corner the wider it sweeps.
-//
-// Taking the larger keeps the approach honest at both ends. Dropping the
-// deflection term lets a shallow corner be planned from a radius it never
-// drives, which starts the turn too late and overlaps the leg it came in on.
-double cornerRadius(const F2CRobot& robot, double sweep, bool continuous) {
-  const double min_radius = robot.getMinTurningRadius();
-  const double rate = robot.getMaxDiffCurv();
-  if (!continuous || rate <= 0.0) {
-    return min_radius;
-  }
-  double radius = std::max(min_radius, PathPlanning::getSmoothTurningRadius(robot));
-  if (sweep > 0.0) {
-    radius = std::max(radius, 1.0 / std::sqrt(rate * sweep));
-  }
-  return radius;
-}
-
-// How far rounding a corner may leave the track. Floored in turning radii,
-// capped at the operation width: a compact implement (radius close to its own
-// width) still gets room for a fillet, but a wide-turning one doesn't get a
-// tolerance loose enough to cut corners it should instead leave sharp.
-double cutTolerance(const F2CRobot& robot) {
-  return std::max(
-      std::min(kCutTolRadii * robot.getMinTurningRadius(), robot.getCovWidth()),
-      kCutTolWidths * robot.getCovWidth());
-}
-
-// Point `dist` along the ray from `from` to `to`; `from` itself if they coincide.
-F2CPoint pointAlong(const F2CPoint& from, const F2CPoint& to, double dist) {
-  if (from.distance(to) < 1e-9) {
-    return from;
-  }
-  return from.getPointFromAngle((to - from).getAngleFromPoint(), dist);
-}
-
-// Furthest any state of `arc` strays from the polyline it stands in for.
-double deviationFromTrack(const F2CPath& arc, const std::vector<F2CPoint>& track) {
-  double worst = 0.0;
-  for (auto&& s : arc.getStates()) {
-    double nearest = std::numeric_limits<double>::max();
-    for (size_t k = 0; k + 1 < track.size(); ++k) {
-      nearest = std::min(nearest, s.point.distance(F2CLineString(track[k], track[k + 1])));
-    }
-    worst = std::max(worst, nearest);
-  }
-  return worst;
+  path.appendStraight(a, b, robot.getCruiseVel(),
+      f2c::types::PathSectionType::HL_SWATH);
 }
 
 // Follow `poly`: straight runs as they are, corners through the turn planner.
+// A corner only a turn cutting past `cut_tol` could round is left square.
 // `start_angle`/`end_angle` are the swath headings at either end, unset if
 // there's none -- the track's own first/last leg is often a spur off the
-// border graph the robot never drives (see PR-4, B.3). Returns the count of
-// corners left sharp because no maneuver fit within `cut_tol` of the track.
-size_t appendRoundedTrack(
+// border graph the robot never drives (see PR-4, B.3).
+void appendRoundedTrack(
     F2CPath& path, const std::vector<F2CPoint>& poly, const F2CRobot& robot,
     TurningBase& turn, double cut_tol, bool continuous,
     const std::optional<double>& start_angle, const std::optional<double>& end_angle) {
   const double radius = robot.getMinTurningRadius();
-  const double op_width = robot.getCovWidth();
   const size_t n = poly.size();
   const auto legAngle = [&poly](size_t a, size_t b) {
       return (poly[b] - poly[a]).getAngleFromPoint();
@@ -138,11 +50,10 @@ size_t appendRoundedTrack(
     sweeps.back() = F2CPoint::getAngleDiffAbs(legAngle(n - 2, n - 1), *end_angle);
   }
 
-  size_t sharp = 0;
   F2CPoint cursor = poly.front();
   size_t i = 0;
   while (i < n) {
-    if (sweeps[i] < kMinSweep) {
+    if (sweeps[i] < robot.getMinSweep()) {
       addStraight(path, robot, cursor, poly[i]);
       cursor = poly[i];
       ++i;
@@ -151,16 +62,17 @@ size_t appendRoundedTrack(
 
     // Corners too close together to round one at a time fold into one span.
     size_t min_span = 1;
-    while (i + min_span < n && min_span < kMaxSpan &&
-        sweeps[i + min_span] >= kMinSweep &&
+    while (i + min_span < n && min_span < robot.getMaxCornerSpan() &&
+        sweeps[i + min_span] >= robot.getMinSweep() &&
         poly[i + min_span - 1].distance(poly[i + min_span]) <
-            2.0 * kRadiusMargin * radius) {
+            2.0 * robot.getRadiusMargin() * radius) {
       ++min_span;
     }
 
     bool rounded = false;
     // Widening out from there, because a shorter span cuts less corner.
-    for (size_t span = min_span; span <= kMaxSpan && i + span <= n && !rounded; ++span) {
+    for (size_t span = min_span;
+        span <= robot.getMaxCornerSpan() && i + span <= n && !rounded; ++span) {
       const size_t j = i + span - 1;  // last corner taken in one go
       // At either end the pose is pinned to the swath, not slid along a leg.
       const bool pin_in = (i == 0);
@@ -184,32 +96,33 @@ size_t appendRoundedTrack(
           *end_angle : (after - last_corner).getAngleFromPoint();
       const double net = F2CPoint::getAngleDiffAbs(in_angle, out_angle);
 
-      const bool tail = (j + 2 == n) && sweeps[n - 1] < kMinSweep;
+      const bool tail = (j + 2 == n) && sweeps[n - 1] < robot.getMinSweep();
       const double back_room = pin_in ? 0.0 : cursor.distance(first);
       const double fwd_room = pin_out ? 0.0 :
-          (tail ? 1.0 : kLegShare) * last_corner.distance(after);
+          (tail ? 1.0 : robot.getLegShare()) * last_corner.distance(after);
       const double room = pin_in ? fwd_room : (pin_out ? back_room :
           std::min(back_room, fwd_room));
 
       // A short reversal is a u-turn (swings past the vertices into the
       // headland), not a corner to fillet; a long one is a detour to follow.
       const double hop = first.distance(last_corner);
-      const bool uturn = net > kReversalSweep && hop < kUturnHopWidths * op_width;
+      const bool uturn =
+          net > robot.getReversalSweep() && hop < robot.getUturnMaxHop();
 
       // Offset of the outgoing leg from the entry heading's line.
       const double sep = std::fabs(
           std::cos(in_angle) * (after.getY() - first.getY()) -
           std::sin(in_angle) * (after.getX() - first.getX()));
 
-      double lo = kMinBackoffRadii * cornerRadius(robot, net, continuous);
+      const double turn_radius = robot.getTurnRadius(net, continuous);
+      double lo = robot.getMinBackoffRadii() * turn_radius;
       double hi = room;
       if (!uturn) {
         if (net > M_PI - 1e-3) {
           continue;  // reversal too wide to be anything but a detour
         }
-        const double tangent_margin = continuous ? kRadiusMargin : 1.0;
-        lo = std::max(
-            tangent_margin * cornerRadius(robot, net, continuous) * std::tan(0.5 * net), lo);
+        const double tangent_margin = continuous ? robot.getRadiusMargin() : 1.0;
+        lo = std::max(tangent_margin * turn_radius * std::tan(0.5 * net), lo);
         hi = std::min(hi, cut_tol / std::max(std::tan(0.25 * net), 1e-6));
       }
       // On a jog net cancels to ~0 and the tan(net/4) bound with it; fall
@@ -218,7 +131,7 @@ size_t appendRoundedTrack(
       // measure that against -- `after` is the corner itself -- so the bound
       // would collapse to zero and refuse a corner the tangent bound allows.
       if (!pin_out || j > i) {
-        hi = std::min(hi, sep + kRadiusMargin * (1.0 + total) * radius);
+        hi = std::min(hi, sep + robot.getRadiusMargin() * (1.0 + total) * radius);
       }
       if (lo > hi) {
         continue;
@@ -229,7 +142,7 @@ size_t appendRoundedTrack(
       double in_reach = hi;
       double out_reach = hi;
       if (uturn) {
-        const double reach = kUturnReachRadii * cornerRadius(robot, net, continuous);
+        const double reach = robot.getUturnReachRadii() * turn_radius;
         in_reach = std::max(lo, std::min(back_room, reach));
         out_reach = std::max(lo, std::min(fwd_room, reach));
       }
@@ -251,8 +164,8 @@ size_t appendRoundedTrack(
       for (const double frac : fracs) {
         const double back_off = pin_in ? 0.0 : lo + frac * (in_reach - lo);
         const double fwd_off = pin_out ? 0.0 : lo + frac * (out_reach - lo);
-        const F2CPoint entry = pointAlong(first, cursor, back_off);
-        const F2CPoint exit = pointAlong(last_corner, after, fwd_off);
+        const F2CPoint entry = first.getPointAlong(cursor, back_off);
+        const F2CPoint exit = last_corner.getPointAlong(after, fwd_off);
         F2CPath arc = turn.createTurn(robot, entry, in_angle, exit, out_angle);
         if (arc.size() == 0) {
           continue;
@@ -268,7 +181,7 @@ size_t appendRoundedTrack(
           turned += F2CPoint::getAngleDiffAbs(arc[k].angle, arc[k - 1].angle);
         }
         // A u-turn earns its teardrop; anything else should turn once.
-        if (turned > total + (uturn ? M_PI : kTurnSlack)) {
+        if (turned > total + (uturn ? M_PI : robot.getTurnSlack())) {
           continue;
         }
 
@@ -278,10 +191,9 @@ size_t appendRoundedTrack(
         }
         track.push_back(exit);
         // A u-turn is allowed the corridor plus the diameter it swings past.
-        const double dev = deviationFromTrack(arc, track);
         const double dev_max = uturn ?
-            cut_tol + 2.0 * cornerRadius(robot, net, continuous) : cut_tol;
-        if (dev > dev_max) {
+            cut_tol + 2.0 * turn_radius : cut_tol;
+        if (arc.maxDistanceTo(F2CLineString(track)) > dev_max) {
           continue;
         }
 
@@ -295,14 +207,12 @@ size_t appendRoundedTrack(
     }
 
     if (!rounded) {
-      ++sharp;
       addStraight(path, robot, cursor, poly[i]);
       cursor = poly[i];
       ++i;
     }
   }
   addStraight(path, robot, cursor, poly.back());
-  return sharp;
 }
 
 }  // namespace
@@ -376,9 +286,8 @@ F2CPath PathPlanning::planPathForConnection(const F2CRobot& robot,
     const F2CPoint& p2, double ang2,
     TurningBase& turn) {
   std::vector<F2CPoint> pts{p1};
-  for (size_t i = 0; i < mp.size(); ++i) {
-    pts.push_back(mp[i]);
-  }
+  const std::vector<F2CPoint> mid = mp.toVectorPoint();
+  pts.insert(pts.end(), mid.begin(), mid.end());
   pts.push_back(p2);
 
   // A track close to the straight hop isn't a detour, so drive it direct; a
@@ -387,12 +296,11 @@ F2CPath PathPlanning::planPathForConnection(const F2CRobot& robot,
   for (size_t i = 1; i + 1 < pts.size(); ++i) {
     max_dev = std::max(max_dev, pts[i].distance(F2CLineString(p1, p2)));
   }
-  const double op_width = robot.getCovWidth();
-  bool direct = max_dev < kDirectHopDev * op_width;
+  bool direct = max_dev < robot.getDirectHopMaxDev();
   if (!direct) {
     const double reversal = F2CPoint::getAngleDiffAbs(ang1, ang2);
     const double hop = p1.distance(p2);
-    direct = reversal > kReversalSweep && hop < kUturnHopWidths * op_width;
+    direct = reversal > robot.getReversalSweep() && hop < robot.getUturnMaxHop();
   }
   if (direct) {
     return turn.createTurn(robot, p1, ang1, p2, ang2);
@@ -400,29 +308,20 @@ F2CPath PathPlanning::planPathForConnection(const F2CRobot& robot,
 
   // Otherwise follow the detour, rounding its corners, rather than cutting
   // across ground the route deliberately routed around.
-  F2CLineString simplified = F2CLineString(pts).simplify(kSimplifyTol * op_width);
-  std::vector<F2CPoint> poly;
-  for (size_t i = 0; i < simplified.size(); ++i) {
-    poly.push_back(simplified[i]);
-  }
+  const std::vector<F2CPoint> poly =
+      F2CLineString(pts).simplify(robot.getTrackSimplifyTol()).toVectorPoint();
   if (poly.size() < 2) {
     return {};
   }
 
   F2CPath path;
-  appendRoundedTrack(path, poly, robot, turn, cutTolerance(robot),
+  appendRoundedTrack(path, poly, robot, turn, robot.getMaxCornerCut(),
       turn.hasContinuousCurvature(), ang1, ang2);
   return path;
 }
 
 double PathPlanning::getSmoothTurningRadius(const F2CRobot& robot) {
-  double x, y, ang, k;
-  end_of_clothoid(0.0, 0.0, 0.0, 0.0, robot.getMaxDiffCurv(), 1.0,
-      robot.getMaxCurv() / robot.getMaxDiffCurv(),
-      &x, &y, &ang, &k);
-  double xi = x - sin(ang) / robot.getMaxCurv();
-  double yi = y + cos(ang) / robot.getMaxCurv();
-  return sqrt(xi*xi + yi*yi);
+  return robot.getSmoothTurningRadius();
 }
 
 }  // namespace f2c::pp

--- a/src/fields2cover/types/LineString.cpp
+++ b/src/fields2cover/types/LineString.cpp
@@ -50,6 +50,15 @@ size_t LineString::size() const {
   return isEmpty() ? 0 : this->data_->getNumPoints();
 }
 
+std::vector<Point> LineString::toVectorPoint() const {
+  std::vector<Point> points;
+  points.reserve(this->size());
+  for (size_t i = 0; i < this->size(); ++i) {
+    points.emplace_back(this->getGeometry(i));
+  }
+  return points;
+}
+
 
 void LineString::getGeometry(size_t i, Point& point) {
   if (i >= this->size()) {

--- a/src/fields2cover/types/MultiPoint.cpp
+++ b/src/fields2cover/types/MultiPoint.cpp
@@ -31,6 +31,15 @@ size_t MultiPoint::size() const {
   return isEmpty() ? 0 : this->data_->getNumGeometries();
 }
 
+std::vector<Point> MultiPoint::toVectorPoint() const {
+  std::vector<Point> points;
+  points.reserve(this->size());
+  for (size_t i = 0; i < this->size(); ++i) {
+    points.emplace_back(this->getGeometry(i));
+  }
+  return points;
+}
+
 void MultiPoint::getGeometry(size_t i, Point& point) {
   if (i >= this->size()) {
     throw std::out_of_range(

--- a/src/fields2cover/types/Path.cpp
+++ b/src/fields2cover/types/Path.cpp
@@ -4,6 +4,7 @@
 //                        BSD-3 License
 //=============================================================================
 
+#include <algorithm>
 #include <numeric>
 #include <steering_functions/utilities/utilities.hpp>
 #include "fields2cover/utils/spline.h"
@@ -225,6 +226,30 @@ void Path::appendSwath(
     s.velocity = cruise_speed;
     this->addState(s);
   }
+}
+
+void Path::appendStraight(const Point& start, const Point& end,
+    double cruise_speed, PathSectionType type) {
+  const double len = start.distance(end);
+  if (len < 1e-6) {
+    return;
+  }
+  PathState s;
+  s.point = start;
+  s.angle = (end - start).getAngleFromPoint();
+  s.len = len;
+  s.dir = PathDirection::FORWARD;
+  s.type = type;
+  s.velocity = cruise_speed;
+  this->addState(s);
+}
+
+double Path::maxDistanceTo(const LineString& line) const {
+  double worst = 0.0;
+  for (auto&& s : this->states_) {
+    worst = std::max(worst, s.point.distance(line));
+  }
+  return worst;
 }
 
 PathState Path::at(double len) const {

--- a/src/fields2cover/types/Path.cpp
+++ b/src/fields2cover/types/Path.cpp
@@ -208,6 +208,11 @@ double Path::length() const {
 }
 
 void Path::appendSwath(const Swath& swath, double cruise_speed) {
+  this->appendSwath(swath, cruise_speed, PathSectionType::SWATH);
+}
+
+void Path::appendSwath(
+    const Swath& swath, double cruise_speed, PathSectionType type) {
   for (size_t i = 0; i < swath.numPoints() - 1; ++i) {
     PathState s;
     s.point = swath.getPoint(i);
@@ -216,7 +221,7 @@ void Path::appendSwath(const Swath& swath, double cruise_speed) {
     s.angle = p_ang.getAngleFromPoint();
     s.len = swath.getPoint(i + 1).distance(swath.getPoint(i));
     s.dir = PathDirection::FORWARD;
-    s.type = PathSectionType::SWATH;
+    s.type = type;
     s.velocity = cruise_speed;
     this->addState(s);
   }

--- a/src/fields2cover/types/Path.cpp
+++ b/src/fields2cover/types/Path.cpp
@@ -298,14 +298,16 @@ std::string Path::serializePath(size_t digit_precision) const {
 }
 
 /**
- * @brief Discretize the swath sections of the path and return a new path
+ * @brief Discretize the swath and headland-swath sections of the path and
+ *        return a new path
  * @param step_size Discretization step in [m]
- * @return New path with swath now discretized
+ * @return New path with swath and headland-swath sections now discretized
 */
 Path Path::discretizeSwath(double step_size) const {
   Path new_path;
   for (auto&& s : this->states_) {
-    if (s.type == PathSectionType::SWATH) {
+    if (s.type == PathSectionType::SWATH ||
+        s.type == PathSectionType::HL_SWATH) {
       double n_steps = max(1.0, std::round(fabs(s.len / step_size)));
       Point start2end = s.atEnd() - s.point;
       for (double j = 0.0; j < n_steps; j += 1.0) {

--- a/src/fields2cover/types/Point.cpp
+++ b/src/fields2cover/types/Point.cpp
@@ -146,6 +146,13 @@ Point Point::getPointFromAngle(double angle, double dist) const {
   return Point(X() + dist * cos(angle), Y() + dist * sin(angle));
 }
 
+Point Point::getPointAlong(const Point& to, double dist) const {
+  if (this->distance(to) < 1e-9) {
+    return *this;
+  }
+  return this->getPointFromAngle((to - *this).getAngleFromPoint(), dist);
+}
+
 double Point::signedDistance2Segment(
     const Point& start, const Point& end) const {
   Point this2start {start - *this};

--- a/src/fields2cover/types/Robot.cpp
+++ b/src/fields2cover/types/Robot.cpp
@@ -5,6 +5,8 @@
 //=============================================================================
 
 
+#include <algorithm>
+#include <steering_functions/utilities/utilities.hpp>
 #include "fields2cover/types/Robot.h"
 
 namespace f2c::types {
@@ -92,6 +94,133 @@ double Robot::getMaxDiffCurv() const {
 
 void Robot::setMaxDiffCurv(double dc) {
   this->linear_curv_change_ = fabs(dc);
+}
+
+double Robot::getSmoothTurningRadius() const {
+  double x, y, ang, k;
+  end_of_clothoid(0.0, 0.0, 0.0, 0.0, this->getMaxDiffCurv(), 1.0,
+      this->getMaxCurv() / this->getMaxDiffCurv(),
+      &x, &y, &ang, &k);
+  double xi = x - sin(ang) / this->getMaxCurv();
+  double yi = y + cos(ang) / this->getMaxCurv();
+  return sqrt(xi * xi + yi * yi);
+}
+
+double Robot::getTurnRadius(double sweep, bool continuous) const {
+  const double min_radius = this->getMinTurningRadius();
+  const double rate = this->getMaxDiffCurv();
+  if (!continuous || rate <= 0.0) {
+    return min_radius;
+  }
+  double radius = std::max(min_radius, this->getSmoothTurningRadius());
+  if (sweep > 0.0) {
+    radius = std::max(radius, 1.0 / sqrt(rate * sweep));
+  }
+  return radius;
+}
+
+double Robot::getMaxCornerCut() const {
+  if (this->max_corner_cut_) {
+    return *this->max_corner_cut_;
+  }
+  return std::max(
+      std::min(this->getMinTurningRadius(), this->cov_width_),
+      0.5 * this->cov_width_);
+}
+
+void Robot::setMaxCornerCut(double d) {
+  this->max_corner_cut_ = fabs(d);
+}
+
+double Robot::getDirectHopMaxDev() const {
+  return this->direct_hop_max_dev_ ?
+      *this->direct_hop_max_dev_ : 0.25 * this->cov_width_;
+}
+
+void Robot::setDirectHopMaxDev(double d) {
+  this->direct_hop_max_dev_ = fabs(d);
+}
+
+double Robot::getUturnMaxHop() const {
+  return this->uturn_max_hop_ ?
+      *this->uturn_max_hop_ : 3.0 * this->cov_width_;
+}
+
+void Robot::setUturnMaxHop(double d) {
+  this->uturn_max_hop_ = fabs(d);
+}
+
+double Robot::getTrackSimplifyTol() const {
+  return this->track_simplify_tol_ ?
+      *this->track_simplify_tol_ : 0.1 * this->cov_width_;
+}
+
+void Robot::setTrackSimplifyTol(double d) {
+  this->track_simplify_tol_ = fabs(d);
+}
+
+double Robot::getReversalSweep() const {
+  return this->reversal_sweep_;
+}
+
+void Robot::setReversalSweep(double a) {
+  this->reversal_sweep_ = fabs(a);
+}
+
+double Robot::getTurnSlack() const {
+  return this->turn_slack_;
+}
+
+void Robot::setTurnSlack(double a) {
+  this->turn_slack_ = fabs(a);
+}
+
+double Robot::getMinSweep() const {
+  return this->min_sweep_;
+}
+
+void Robot::setMinSweep(double a) {
+  this->min_sweep_ = fabs(a);
+}
+
+double Robot::getLegShare() const {
+  return this->leg_share_;
+}
+
+void Robot::setLegShare(double s) {
+  this->leg_share_ = fabs(s);
+}
+
+double Robot::getRadiusMargin() const {
+  return this->radius_margin_;
+}
+
+void Robot::setRadiusMargin(double m) {
+  this->radius_margin_ = fabs(m);
+}
+
+double Robot::getMinBackoffRadii() const {
+  return this->min_backoff_radii_;
+}
+
+void Robot::setMinBackoffRadii(double r) {
+  this->min_backoff_radii_ = fabs(r);
+}
+
+double Robot::getUturnReachRadii() const {
+  return this->uturn_reach_radii_;
+}
+
+void Robot::setUturnReachRadii(double r) {
+  this->uturn_reach_radii_ = fabs(r);
+}
+
+size_t Robot::getMaxCornerSpan() const {
+  return this->max_corner_span_;
+}
+
+void Robot::setMaxCornerSpan(size_t n) {
+  this->max_corner_span_ = n;
 }
 
 }  // namespace f2c::types

--- a/tests/cpp/path_planning/path_planning_test.cpp
+++ b/tests/cpp/path_planning/path_planning_test.cpp
@@ -183,10 +183,8 @@ TEST(fields2cover_pp_pp, curvedConnectionIsNotFlattened) {
 }
 
 TEST(fields2cover_pp_pp, unroundableCornerKeepsTheTrack) {
-  // With a turning circle far wider than the corridor, no maneuver fits
-  // through the corner. The corner then stays sharp on purpose: cutting it
-  // would put the vehicle off the planned track, which is worse than a step
-  // the controller has to absorb.
+  // There's room for the turn; at this radius it would just cut too much off
+  // the corner. So it stays square rather than driving off the planned track.
   F2CRobot robot = connectionTestRobot(8.0, 2.5);
   f2c::pp::PathPlanning path_planner;
   f2c::pp::DubinsCurvesCC dubins_cc;

--- a/tests/cpp/path_planning/path_planning_test.cpp
+++ b/tests/cpp/path_planning/path_planning_test.cpp
@@ -11,7 +11,7 @@
 #include "../test_helpers/path_planning_checker.hpp"
 #include "../test_helpers/robot_data.hpp"
 
-TEST(DISABLED_fields2cover_pp_pp, planPathForConnection) {
+TEST(fields2cover_pp_pp, planPathForConnection) {
   F2CRobot robot = getSimpleRobot();
   f2c::pp::PathPlanning path_planner;
   f2c::pp::DubinsCurves dubins;

--- a/tests/cpp/path_planning/path_planning_test.cpp
+++ b/tests/cpp/path_planning/path_planning_test.cpp
@@ -5,11 +5,31 @@
 //=============================================================================
 
 #include <gtest/gtest.h>
+#include <cmath>
 #include <numeric>
 #include <fstream>
 #include "fields2cover.h"
 #include "../test_helpers/path_planning_checker.hpp"
 #include "../test_helpers/robot_data.hpp"
+
+
+namespace {
+
+F2CRobot connectionTestRobot(double min_turning_radius = 0.4, double cov_width = 2.5) {
+  F2CRobot robot(2.1, cov_width);
+  robot.setMinTurningRadius(min_turning_radius);
+  robot.setMaxDiffCurv(2.0);
+  return robot;
+}
+
+// Two opposing swaths with a gap between them, for connections to span.
+void makeSwaths(double x_second, F2CSwaths& first, F2CSwaths& second) {
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+  second.emplace_back(
+      F2CSwath(F2CLineString({F2CPoint(x_second, 20), F2CPoint(x_second, 0)})));
+}
+
+}  // namespace
 
 TEST(fields2cover_pp_pp, planPathForConnection) {
   F2CRobot robot = getSimpleRobot();
@@ -34,5 +54,305 @@ TEST(fields2cover_pp_pp, planPathForConnection) {
   EXPECT_TRUE(isPathCorrect(path1));
   EXPECT_TRUE(isPathCorrect(path2));
   EXPECT_TRUE(isPathCorrect(path3));
+}
+
+TEST(fields2cover_pp_pp, connectionCornersAreSmoothed) {
+  // Corners of a detouring connection must go through the turn planner: a raw
+  // boundary vertex is a heading step no turning radius can hold.
+  F2CRobot robot = connectionTestRobot();
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths first, second;
+  makeSwaths(30.0, first, second);
+
+  // Connection detours over the top with two right-angle corners.
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+      F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(30, 40), F2CPoint(30, 20)}),
+      second);
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);  // a square corner would leave a ~1.57 rad step
+
+  // Smoothing must round the corners, not skip the detour: a path that cut
+  // straight across would satisfy the heading bound above on its own.
+  EXPECT_LT(distanceToPath(path, F2CPoint(15, 40)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 30)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(30, 30)), 0.5);
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
+}
+
+TEST(fields2cover_pp_pp, connectionJogIsSmoothed) {
+  // A jog with two corners a couple of metres apart: too tight to take one at
+  // a time, so it has to be rounded as a single S rather than driven square.
+  F2CRobot robot = connectionTestRobot();
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths first, second;
+  makeSwaths(30.0, first, second);
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+      F2CMultiPoint({
+          F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(14, 40), F2CPoint(16, 42),
+          F2CPoint(30, 42), F2CPoint(30, 20)}),
+      second);
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);
+  EXPECT_LT(distanceToPath(path, F2CPoint(25, 42)), 0.5);
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
+}
+
+TEST(fields2cover_pp_pp, neighbourUturnIsPlannedAsATurn) {
+  // Neighbouring swaths doubling back on each other. The track wanders out
+  // past the straight-hop tolerance, but this is still a u-turn, not a corner
+  // to round: driving its two vertices square would put a pair of right
+  // angles where the headland maneuver belongs.
+  F2CRobot robot = connectionTestRobot();
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths first, second;
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+  second.emplace_back(F2CSwath(F2CLineString({F2CPoint(2.5, 20), F2CPoint(2.5, 0)})));
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+      F2CMultiPoint(
+          {F2CPoint(0, 20), F2CPoint(0, 21.5), F2CPoint(2.5, 21.5), F2CPoint(2.5, 20)}),
+      second);
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  // Squaring off the two vertices would leave ~1.57 rad steps at each.
+  EXPECT_LT(maxHeadingStep(path), 1.0);
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
+}
+
+TEST(fields2cover_pp_pp, curvedConnectionIsNotFlattened) {
+  // Every point of this arc sits millimetres from the chord of its immediate
+  // neighbours, so simplifying by local collinearity would drop them one by
+  // one and collapse a 5m bulge onto its chord. The kept track must stay on
+  // the arc.
+  F2CRobot robot = connectionTestRobot();
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths first, second;
+  makeSwaths(40.0, first, second);
+
+  F2CMultiPoint arc;
+  for (int k = 0; k <= 40; ++k) {
+    const double x = static_cast<double>(k);
+    arc.addPoint(F2CPoint(x, 20.0 + 5.0 * std::sin(M_PI * x / 40.0)));
+  }
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(arc, second);
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  // A junction corner left unrounded shows up here as a ~70 degree step.
+  EXPECT_LT(maxHeadingStep(path), 1.0);
+
+  EXPECT_LT(distanceToPath(path, F2CPoint(20, 25)), 0.5);   // apex
+  EXPECT_LT(distanceToPath(path, F2CPoint(10, 23.54)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(30, 23.54)), 0.5);
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
+}
+
+TEST(fields2cover_pp_pp, unroundableCornerKeepsTheTrack) {
+  // With a turning circle far wider than the corridor, no maneuver fits
+  // through the corner. The corner then stays sharp on purpose: cutting it
+  // would put the vehicle off the planned track, which is worse than a step
+  // the controller has to absorb.
+  F2CRobot robot = connectionTestRobot(8.0, 2.5);
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths first, second;
+  makeSwaths(30.0, first, second);
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+      F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(30, 40), F2CPoint(30, 20)}),
+      second);
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  // Corners themselves, not just their neighbourhood: nothing may be cut here.
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 40)), 0.1);
+  EXPECT_LT(distanceToPath(path, F2CPoint(30, 40)), 0.1);
+}
+
+TEST(fields2cover_pp_pp, swathHeadingRoundsTheJunction) {
+  // The junction with a swath is a corner: the connection need not leave
+  // along the heading the swath holds. Without that heading it is not seen
+  // as one.
+  F2CRobot robot = connectionTestRobot();
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  // Swath runs east and ends where the connection sets off north.
+  F2CSwaths first, second;
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(-20, 20), F2CPoint(0, 20)})));
+  second.emplace_back(F2CSwath(F2CLineString({F2CPoint(30, 20), F2CPoint(30, 0)})));
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+      F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(30, 40), F2CPoint(30, 20)}),
+      second);
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);  // driven straight off, a ~1.57 rad step
+
+  // Starts on the swath's own end pose, not up the leg at the next vertex.
+  auto turns = turnStarts(path);
+  ASSERT_FALSE(turns.empty());
+  EXPECT_NEAR(turns.front().getX(), 0.0, 1e-3);
+  EXPECT_NEAR(turns.front().getY(), 20.0, 1e-3);
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
+}
+
+TEST(fields2cover_pp_pp, openEndedConnectionFollowsTheTrack) {
+  // Route-end connections have a swath on one side only. The open end holds
+  // no heading, so it is no corner, and nothing may be read off it.
+  F2CRobot robot = connectionTestRobot();
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths swaths;
+  swaths.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+
+  // A lead-in from off the field, and a lead-out back off it.
+  F2CRoute route;
+  route.addConnectedSwaths(
+      F2CMultiPoint({F2CPoint(-20, -20), F2CPoint(0, -20), F2CPoint(0, 0)}), swaths);
+  route.addConnection(
+      F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(-20, 40)}));
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);
+
+  // One corner each; the open ends are driven through.
+  EXPECT_EQ(turnStarts(path).size(), 2u);
+
+  EXPECT_LT(distanceToPath(path, F2CPoint(-10, -20)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 30)), 0.5);
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
+}
+
+TEST(fields2cover_pp_pp, shallowCornerKeepsAnApproach) {
+  // A shallow corner's fillet tangent collapses with it. The floor under
+  // that is what leaves the planner a maneuver rather than two poses 6cm
+  // apart.
+  F2CRobot robot = connectionTestRobot();
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths swaths;
+  swaths.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+
+  // Lead-out bending 15deg at (0, 50), well over the ~3deg driven straight.
+  const double bend = 15.0 * M_PI / 180.0;
+  const F2CPoint corner(0, 50);
+  const F2CPoint tip(30.0 * std::sin(bend), 50.0 + 30.0 * std::cos(bend));
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), swaths);
+  route.addConnection(F2CMultiPoint({F2CPoint(0, 20), corner, tip}));
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  // Rounded rather than left sharp, and the only corner on the route.
+  auto turns = turnStarts(path);
+  ASSERT_EQ(turns.size(), 1u);
+
+  // Two-sided: 6cm of tangent here, nothing to turn in, so it must start
+  // further back -- but not so far back that it leaves the leg early and
+  // cuts ground the swath either side of it is covering. A shallow corner
+  // is driven at a wider radius than a sharp one, and sizing the approach
+  // from the sharp-corner radius is what pushes the start out.
+  EXPECT_GT(turns.front().distance(corner), 0.15);
+  EXPECT_LT(turns.front().distance(corner), 2.0);
+
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 35)), 0.5);  // leg in followed
+  // The leg out is one state with no point at its end, so check its heading.
+  EXPECT_NEAR(path[path.size() - 1].angle, M_PI / 2.0 - bend, 1e-3);
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
+}
+
+TEST(fields2cover_pp_pp, tightCornersAreFoldedIntoOneTurn) {
+  // Corners too close to round one at a time: rounding the first leaves the
+  // second no approach, so the pair has to be taken as one S.
+  //
+  // The radius sets how close is too close. At the default 0.4m the jog
+  // would be small enough to pass as a straight hop and never reach the
+  // rounding.
+  F2CRobot robot = connectionTestRobot(2.0, 2.5);
+  f2c::pp::PathPlanning path_planner;
+  f2c::pp::DubinsCurvesCC dubins_cc;
+
+  F2CSwaths first, second;
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+  second.emplace_back(F2CSwath(F2CLineString({F2CPoint(3, 63), F2CPoint(3, 83)})));
+
+  // Corners at (0,40) and (3,43): 4.24m apart, inside the 4.8m a turn needs.
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+      F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(3, 43), F2CPoint(3, 63)}),
+      second);
+
+  auto path = path_planner.planPath(robot, route, dubins_cc);
+  ASSERT_GT(path.size(), 2u);
+
+  // Taken one at a time they would each round here, and leave two.
+  EXPECT_EQ(turnStarts(path).size(), 1u);
+
+  // Their deflections cancel, so nothing bounds the fold by the corner it
+  // cuts. It still has to make the jog: this is the midpoint of the leg
+  // between them.
+  EXPECT_LT(distanceToPath(path, F2CPoint(1.5, 41.5)), 0.5);
+
+  EXPECT_LT(maxHeadingStep(path), 0.2);  // square corners leave ~0.79 rad
+  // No connection turn may sweep past a u-turn: more than that is a loop,
+  // which is smooth and barely longer, so nothing else here would catch it.
+  EXPECT_LT(maxTurnSweep(path), M_PI + 0.2);
 }
 

--- a/tests/cpp/test_helpers/path_planning_checker.hpp
+++ b/tests/cpp/test_helpers/path_planning_checker.hpp
@@ -9,7 +9,10 @@
 #define PATH_PLANNING_CHECKER_HPP_
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <fstream>
+#include <limits>
+#include <vector>
 #include "fields2cover.h"
 
 
@@ -88,6 +91,71 @@ inline testing::AssertionResult IsPathCorrect(
       start.distance(end) << ").";
   }
   return isPathCorrect(path);
+}
+
+// Distance from `q` to the polyline through the path's states. Straight runs
+// are a single state, so measuring to the states alone would miss the track
+// in between.
+inline double distanceToPath(const F2CPath& path, const F2CPoint& q) {
+  double best = std::numeric_limits<double>::max();
+  for (size_t i = 1; i < path.size(); ++i) {
+    best = std::min(best,
+        q.distance(F2CLineString(path[i - 1].point, path[i].point)));
+  }
+  return best;
+}
+
+// Largest heading jump between consecutive states.
+inline double maxHeadingStep(const F2CPath& path) {
+  double worst = 0.0;
+  for (size_t i = 1; i < path.size(); ++i) {
+    worst = std::max(worst,
+        F2CPoint::getAngleDiffAbs(path[i].angle, path[i - 1].angle));
+  }
+  return worst;
+}
+
+// Widest heading excursion of any single turn: how far its running signed
+// heading change spreads. A corner or an S stays inside half a revolution;
+// a loop runs past a full one. Length and maxHeadingStep both miss a loop,
+// because it is smooth and only 2*pi*R longer.
+inline double maxTurnSweep(const F2CPath& path) {
+  double worst = 0.0;
+  size_t i = 0;
+  while (i < path.size()) {
+    if (path[i].type != f2c::types::PathSectionType::TURN) {
+      ++i;
+      continue;
+    }
+    double run = 0.0, lo = 0.0, hi = 0.0;
+    for (++i; i < path.size() &&
+        path[i].type == f2c::types::PathSectionType::TURN; ++i) {
+      double d = path[i].angle - path[i - 1].angle;
+      run += atan2(sin(d), cos(d));       // signed, wrap-safe
+      lo = std::min(lo, run);
+      hi = std::max(hi, run);
+    }
+    worst = std::max(worst, hi - lo);
+  }
+  return worst;
+}
+
+// First point of each maximal run of TURN-type states, in order -- the
+// entry pose of each connection turn the path was rounded through.
+inline std::vector<F2CPoint> turnStarts(const F2CPath& path) {
+  std::vector<F2CPoint> starts;
+  bool in_turn = false;
+  for (auto&& s : path) {
+    if (s.type == f2c::types::PathSectionType::TURN) {
+      if (!in_turn) {
+        starts.push_back(s.point);
+      }
+      in_turn = true;
+    } else {
+      in_turn = false;
+    }
+  }
+  return starts;
 }
 
 #endif  // PATH_PLANNING_CHECKER_HPP_

--- a/tests/cpp/types/Path_test.cpp
+++ b/tests/cpp/types/Path_test.cpp
@@ -496,3 +496,86 @@ TEST(fields2cover_types_path, discretize_swath) {
       state2.point, 0.5 * boost::math::constants::half_pi<double>(), false));
 }
 
+TEST(fields2cover_types_path, discretizeSwath_hl_swath) {
+  F2CPath path;
+  F2CPathState state;
+  state.point = F2CPoint(0, 0);
+  state.angle = 0.0;
+  state.len = 10.0;
+  state.type = f2c::types::PathSectionType::HL_SWATH;
+  path.addState(state);
+
+  double step_size = 2.0;
+  F2CPath discretized = path.discretizeSwath(step_size);
+
+  EXPECT_EQ(discretized.size(), 5);
+  for (auto&& s : discretized) {
+    EXPECT_EQ(static_cast<int>(s.type),
+        static_cast<int>(f2c::types::PathSectionType::HL_SWATH));
+    EXPECT_NEAR(s.len, step_size, 1e-6);
+  }
+  EXPECT_NEAR(discretized.length(), path.length(), 1e-6);
+}
+
+TEST(fields2cover_types_path, discretizeSwath_mixed_types) {
+  F2CPath path;
+  F2CPathState swath_state;
+  swath_state.point = F2CPoint(0, 0);
+  swath_state.angle = 0.0;
+  swath_state.len = 4.0;
+  swath_state.type = f2c::types::PathSectionType::SWATH;
+  path.addState(swath_state);
+
+  F2CPathState turn_state;
+  turn_state.point = F2CPoint(4, 0);
+  turn_state.angle = 0.5 * M_PI;
+  turn_state.len = 4.0;
+  turn_state.type = f2c::types::PathSectionType::TURN;
+  path.addState(turn_state);
+
+  F2CPathState hl_state;
+  hl_state.point = F2CPoint(4, 4);
+  hl_state.angle = M_PI;
+  hl_state.len = 4.0;
+  hl_state.type = f2c::types::PathSectionType::HL_SWATH;
+  path.addState(hl_state);
+
+  double step_size = 2.0;
+  F2CPath discretized = path.discretizeSwath(step_size);
+
+  int n_swath = 0, n_turn = 0, n_hl_swath = 0;
+  for (auto&& s : discretized) {
+    switch (s.type) {
+      case f2c::types::PathSectionType::SWATH: ++n_swath; break;
+      case f2c::types::PathSectionType::TURN: ++n_turn; break;
+      case f2c::types::PathSectionType::HL_SWATH: ++n_hl_swath; break;
+    }
+  }
+  EXPECT_EQ(n_swath, 2);
+  EXPECT_EQ(n_turn, 1);
+  EXPECT_EQ(n_hl_swath, 2);
+}
+
+TEST(fields2cover_types_path, serialize_load_preserves_hl_swath) {
+  F2CPath path;
+  F2CPathState state;
+  state.point = F2CPoint(1.0, 2.0);
+  state.angle = 0.25 * M_PI;
+  state.len = 3.0;
+  state.velocity = 1.5;
+  state.type = f2c::types::PathSectionType::HL_SWATH;
+  path.addState(state);
+
+  std::string tmp_file = "/tmp/f2c_hl_swath_roundtrip_test.txt";
+  path.saveToFile(tmp_file);
+
+  F2CPath loaded;
+  loaded.loadFile(tmp_file);
+
+  ASSERT_EQ(loaded.size(), 1);
+  EXPECT_EQ(static_cast<int>(loaded[0].type),
+      static_cast<int>(f2c::types::PathSectionType::HL_SWATH));
+  EXPECT_NEAR(loaded[0].point.getX(), 1.0, 1e-6);
+  EXPECT_NEAR(loaded[0].point.getY(), 2.0, 1e-6);
+}
+

--- a/tests/cpp/types/Path_test.cpp
+++ b/tests/cpp/types/Path_test.cpp
@@ -556,6 +556,21 @@ TEST(fields2cover_types_path, discretizeSwath_mixed_types) {
   EXPECT_EQ(n_hl_swath, 2);
 }
 
+TEST(fields2cover_types_path, appendSwath_with_type) {
+  F2CLineString line(
+      {F2CPoint(0.0, 0.0), F2CPoint(1.0, 0.0), F2CPoint(1.0, 3.0)});
+  F2CSwath swath(line);
+  F2CPath path;
+  path.appendSwath(swath, 2.0, f2c::types::PathSectionType::HL_SWATH);
+
+  EXPECT_EQ(path.size(), 2);
+  for (auto&& s : path) {
+    EXPECT_EQ(static_cast<int>(s.type),
+        static_cast<int>(f2c::types::PathSectionType::HL_SWATH));
+  }
+  EXPECT_EQ(path[0].velocity, 2.0);
+}
+
 TEST(fields2cover_types_path, serialize_load_preserves_hl_swath) {
   F2CPath path;
   F2CPathState state;


### PR DESCRIPTION
### Motivation

`planPathForConnection()` ignores the polyline it is given. It hands every consecutive pose
pair to the turn planner, so a connection detouring around a concave notch or between
decomposed cells is driven straight from one end to the other, cutting across ground the
route deliberately routed around. `simplifyConnection()` also compares headings with
`fabs(ang_in - ang_out)` on raw angles, which wraps wrong.

The library's own test says as much: `planPathForConnection` has been `DISABLED_` since
v2.0.0's first commit, and forcing it to run shows the path coming out shorter than the
track it is meant to follow.

`PathSectionType::HL_SWATH` is equally unfinished — never produced or consumed anywhere,
skipped by `discretizeSwath()`, unreachable through any public API. It is in this PR because
the fix produces it: the straight legs between rounded corners are headland passes, not
turns, and without the `HL_SWATH` half each would be a type `discretizeSwath()` refuses to
subdivide, leaving it a single waypoint.

### 1. Discretize `HL_SWATH` sections (`83dc019`)

`discretizeSwath()` only densified `SWATH` states. One condition, plus the doc comment.

No call path in the tree changes behaviour, because nothing produced the type.

### 2. Let `appendSwath` write the section type (`e9a18f1`)

```cpp
void appendSwath(const Swath& swath, double cruise_speed);                        // existing
void appendSwath(const Swath& swath, double cruise_speed, PathSectionType type);  // added
```

The two-argument form delegates with `SWATH`. An overload rather than a default argument,
so the ABI is untouched.

`setSwathType()`/`setTurnType()` already exist and have no callers in the library — they
are there for the outside, and the third type had no counterpart.

If the preferred answer is to drop the enumerator instead: it is serialized as `3` by
`serializePath`, so removing it changes the file format, and telling a headland pass from
a swath is a real need — `generateHeadlandSwaths` returns rings, and turning one into a
drivable path is the next thing we need from the library.

### 3. Follow and round the connection track (`9c3a06e`)

`planPathForConnection` now walks the polyline: straight runs become `HL_SWATH` legs,
and only genuine corners go to `createTurn`. Corners too close together to take one at a
time are folded into a single maneuver; a corner a turn could only round by cutting past
`cut_tol` is left square instead. A connection whose track stays within a quarter of the operation width
of the straight hop, or one that reverses over a short hop, is still driven direct — the
u-turn between neighbouring swaths is the hop itself, and an arc through a 180-degree
vertex has no tangent length to round with.

Four details decide whether that produces corners or loops. Each was checked by reverting it
and confirming a test goes red:

- **The approach is sized from the radius the turn actually sweeps** — the wider of
  `getSmoothTurningRadius` (public since #233; the clothoid ramps spend part of the
  deflection) and `sqrt(rate * sweep)` (a shallow corner never reaches full curvature). They
  cross around 50 degrees. Take only the first and a shallow corner starts its turn a metre
  early, cutting ground the covering legs either side of it need.
- **A turn is judged by how far it turns, not how long it is.** A loop's extra `2*pi*R` is a
  couple of metres at a small radius — inside any sane length budget, and smooth enough that
  no heading-step check sees it. Turning does not hide it, and it catches doubling-back S
  shapes too.
- **`cut_tol` is floored in turning radii, capped at the operation width.** Tied to the
  width alone, an implement whose turning circle is close to its own width gets every corner
  refused; the cap stops a wide-turning one cutting corners it should leave square.
- **The tangent margin applies only to a continuous-curvature turn**, being room for the
  clothoid lead-in. A discontinuous turn has nothing to ramp.

`simplifyConnection` is removed, body and private declaration. **This closes the second half
of #231 by construction** — the angle-wrap bug lived there, and the new code uses
`Point::getAngleDiffAbs` throughout.

One more fix along the way: at a pinned route end taking a single corner the outgoing
reference point *is* the corner, so the lateral-offset bound collapsed to zero and refused a
corner the tangent bound allowed.

### 4. Tests (`7f7b322`)

`fields2cover_pp_pp.planPathForConnection` is enabled with its expectations untouched.

Nine new tests over behaviour that had no coverage: detour corners, tight jogs folded into
one S, neighbour u-turns, curved tracks that must not be flattened, corners left sharp
because rounding would cut too much, corners taken from the swath's heading not the track's,
open-ended route connections, shallow-corner approach floors, and corners too close to
round one at a time.

`distanceToPath`, `maxHeadingStep`, `turnStarts` and `maxTurnSweep` go into the checker.
`distanceToPath` measures to the polyline through the states rather than to the states
themselves — a straight run is a single state, so measuring to states alone would miss the
track between them. `maxTurnSweep` is the loop fence: it takes the widest excursion of a
turn's running signed heading change, so a corner or an S reads under half a revolution
while a loop runs past a full one.

The shallow-corner test bounds the approach on *both* sides: a turn that starts at the
corner has no tangent to turn in, and one that starts too far back leaves the leg early and
cuts ground the covering legs either side of it need.

One candidate detail was dropped after the same check — adding the clothoid ramp length to
the approach distance. With the turning fence in place it changed no output at all, and at a
swath junction it made the turn slightly wider.

### Known limitations

The tuning constants (`cut_tol`'s fractions, the u-turn thresholds, the span limit) are
`constexpr` in an anonymous namespace rather than parameters. `f2c::pp::PathPlanning` is
entirely static, so exposing them raises a static-vs-instance question that is wider than
this change. Making `cut_tol` a defaulted argument would be a sensible follow-up: how much
ground a machine may cut across depends on the field and on what the implement is doing, so
it is the one an operator would plausibly want to set.

Where a connection meets a swath, the entry pose is the swath's own end pose and cannot
slide back along it, so a continuous-curvature turn there has no approach room and swings
slightly wide before settling. How wide depends on the curvature rate: it is small at rates
a field machine uses and grows as the rate falls. Bounded and drivable, but not as tight as
a corner with room on both sides.
