### PR TITLE
Keep SWIG 4.5 from wrapping uninheritable copy/move constructors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         gcc: [9, 10, 11, 12]
         gdal: ["3.6.3"]
-        swig: ["v4.0.0", "v4.0.1", "v4.0.2", "v4.1.0", "v4.1.1", "v4.2.0", "v4.2.1"]
+        swig: ["v4.0.0", "v4.0.1", "v4.0.2", "v4.1.0", "v4.1.1", "v4.2.0", "v4.2.1", "v4.5.0"]
         shared: ["ON"]
         generators: ["Unix Makefiles"]
         build_type: ["Debug", "Release"]

--- a/include/fields2cover/types/Geometries.h
+++ b/include/fields2cover/types/Geometries.h
@@ -20,7 +20,12 @@ namespace f2c::types {
 template <class SAMETYPE, class T, OGRwkbGeometryType R, class CHILDRENTYPE>
 struct Geometries : public Geometry<T, R> {
  public:
+  // Hidden from SWIG: since 4.5.0 it inherits the base copy/move
+  // constructors through this declaration (C++ never does), which makes
+  // the generated wrapper fail to compile.
+#ifndef SWIG
   using Geometry<T, R>::Geometry;
+#endif
   /// Compute area of the geometry
   double area() const;
   SAMETYPE clone() const;

--- a/include/fields2cover/types/Geometries.h
+++ b/include/fields2cover/types/Geometries.h
@@ -20,9 +20,7 @@ namespace f2c::types {
 template <class SAMETYPE, class T, OGRwkbGeometryType R, class CHILDRENTYPE>
 struct Geometries : public Geometry<T, R> {
  public:
-  // Hidden from SWIG: since 4.5.0 it inherits the base copy/move
-  // constructors through this declaration (C++ never does), which makes
-  // the generated wrapper fail to compile.
+  // Hidden from SWIG, which would also wrap the base copy/move constructors.
 #ifndef SWIG
   using Geometry<T, R>::Geometry;
 #endif

--- a/include/fields2cover/types/Point.h
+++ b/include/fields2cover/types/Point.h
@@ -20,7 +20,12 @@ namespace f2c::types {
 
 struct Point : public Geometry<OGRPoint, wkbPoint> {
  public:
+  // Hidden from SWIG: since 4.5.0 it inherits the base copy/move
+  // constructors through this declaration (C++ never does), which makes
+  // the generated wrapper fail to compile.
+#ifndef SWIG
   using Geometry<OGRPoint, wkbPoint>::Geometry;
+#endif
   Point();
   Point(double x, double y, double z = 0);
   Point(const Point&);

--- a/include/fields2cover/types/Point.h
+++ b/include/fields2cover/types/Point.h
@@ -20,9 +20,7 @@ namespace f2c::types {
 
 struct Point : public Geometry<OGRPoint, wkbPoint> {
  public:
-  // Hidden from SWIG: since 4.5.0 it inherits the base copy/move
-  // constructors through this declaration (C++ never does), which makes
-  // the generated wrapper fail to compile.
+  // Hidden from SWIG, which would also wrap the base copy/move constructors.
 #ifndef SWIG
   using Geometry<OGRPoint, wkbPoint>::Geometry;
 #endif


### PR DESCRIPTION
SWIG 4.5.0 (what Homebrew ships since August) started resolving the C++11 `using Geometry<T, R>::Geometry;` declarations in `Geometries.h` and `Point.h` and now emits wrappers for every base constructor — including the copy and move constructors, which C++ never inherits. The generated `Fields2CoverPYTHON_wrap.cxx` then fails to compile for every geometry type:

```
Fields2CoverPYTHON_wrap.cxx:35136:118: error: no matching constructor for initialization of 'f2c::types::Geometries<f2c::types::MultiPoint, OGRMultiPoint, wkbMultiPoint, f2c::types::Point>'
```

Older SWIG versions silently skipped these declarations (Warning 329, "uses base 'Geometry' which is not an immediate base of …"), which is why CI (up to v4.2.1) never saw it. Not platform-specific — any SWIG ≥ 4.5.0 is affected.

Fix: hide the two `using` lines from SWIG with `#ifndef SWIG`, which restores exactly the previous behaviour. `v4.5.0` is added to the CI matrix so the fix is proven on Linux as well.

<details><summary>What was verified</summary>

Both SWIG 4.4.1 and a 4.5.0 built from source were run on `swig/Fields2Cover.i` for the merge-base and this branch:

- **4.4.1:** wrapper and `fields2cover.py` are byte-identical between merge-base and this branch. 4.4.1 skips all 13 inheriting-constructor declarations (`Geometries.h`, `Point.h`, `MultiPoint.h`, `LinearRing.h`, `LineString.h`, `MultiLineString.h`, `Cell.h`, `Cells.h`) with Warning 329, so the Python API never had them.
- **4.5.0 on merge-base:** `Point` and every `Geometries<…>` instantiation get `(Geometry<…> const&)` / `(Geometry<…>&&)` constructor wrappers — the compile failure above. On this branch they are gone; the derived classes (`MultiPoint` … `Cells`) have the same constructor set under 4.4.1 and 4.5.0, the generated `.py` differs only in SWIG boilerplate, and `tests/python/` passes.
- **Root cause:** SWIG wraps inherited copy/move constructors for any `using Base::Base;` it can resolve — a plain `struct B : A { using A::A; }` reproduces it with 4.4.1 as well. 4.5.0 merely started resolving template-instantiation bases (swig/swig#2951), which exposed it here. `#ifndef SWIG` is therefore the right fix; `%ignore`-ing only the copy/move overloads would leave the other inherited constructors (OGR-typed, opaque in the module) in the Python API for SWIG ≥ 4.5 only.

</details>

Found on a fresh macOS install while testing #228.

<details><summary>Side question: should we lighten up the SWIG testing matrix?</summary>

Adding `v4.5.0` to the full matrix means 8 more jobs (65 in total, ~7 min each). At the same time the matrix runs three pairs that test practically the same thing (`v4.0.0/v4.0.1/v4.0.2`, `v4.1.0/v4.1.1`, `v4.2.0/v4.2.1` — SWIG patch releases are bug-fix only) and skips 4.3.x and 4.4.x entirely, which is what Ubuntu 24.04/25.04 and Fedora ship today. Keeping the tested minimum and the newest patch of each minor:

```yaml
swig: ["v4.0.0", "v4.0.2", "v4.1.1", "v4.2.1", "v4.3.1", "v4.4.1", "v4.5.0"]
```

gives 7 versions — exactly the job count from before this PR (56 + 1) — with 4.3.1 and 4.4.1 covered on top. If that is preferred, I'll add it as a separate commit; otherwise an `include:` entry with 4.5.0 for a single gcc (like the existing `shared: OFF` one) would also keep the CI time flat.

</details>

[Link to the upstream SWIG issue](https://github.com/swig/swig/issues/3543)


---
*Authored with [Claude Fable 5](https://claude.com/claude-code).*
