### PR TITLE
Harden the shortest-path graph: node accounting, node lookup, and border edges

### DIFF
--- a/include/fields2cover/types/Cells.h
+++ b/include/fields2cover/types/Cells.h
@@ -81,6 +81,10 @@ struct Cells : public Geometries<Cells, OGRMultiPolygon, wkbMultiPolygon,
 
   const Cell getCellWherePoint(const Point& p) const;
 
+  /// Get the cell a point belongs to, allowing the point to sit up to
+  /// d_tol outside it. Returns an empty cell if no cell is that close.
+  const Cell getCellWherePoint(const Point& p, double d_tol) const;
+
   LineString createLineUntilBorder(
       const f2c::types::Point& p, double ang) const;
 

--- a/include/fields2cover/types/Graph.h
+++ b/include/fields2cover/types/Graph.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <unordered_set>
 #include <functional>
 #include <utility>
 #include <unordered_map>
@@ -30,7 +31,15 @@ class Graph {
   Graph& removeDirectedEdge(size_t from, size_t to);
   Graph& removeEdge(size_t i, size_t j);
 
+  /// Ids of every node, including nodes that only have incoming edges.
+  std::unordered_set<size_t> getNodes() const;
+
   size_t numNodes() const;
+
+  /// Size of the matrices returned by getCosts() and getPaths().
+  /// Nodes are indexed by their own id, so this is the largest id plus one.
+  size_t matrixSize() const;
+
   size_t numEdges() const;
   map_to_map_to_int getEdges() const;
 

--- a/include/fields2cover/types/Graph2D.h
+++ b/include/fields2cover/types/Graph2D.h
@@ -40,15 +40,23 @@ class Graph2D : public Graph {
   size_t numNodes() const;
   std::vector<Point> getNodes() const;
 
+  /// Check if a point is a node of this graph.
+  bool hasNode(const Point& p) const;
+
   size_t nodeToIndex(const Point& p) const;
   Point indexToNode(size_t id) const;
 
+  /// Paths between two nodes. Empty if either point is not a node.
   std::vector<std::vector<Point>> allPathsBetween(
       const Point& from, const Point& to) const;
 
+  /// Shortest path between two nodes.
+  /// Empty if there is no path or either point is not a node.
   std::vector<Point> shortestPath(const Point& from, const Point& to,
         int64_t INF = 1<<30);
 
+  /// Cost of the shortest path between two nodes.
+  /// INF if there is no path or either point is not a node.
   int64_t shortestPathCost(const Point& from, const Point& to,
         int64_t INF = 1<<30);
 

--- a/include/fields2cover/types/Point.h
+++ b/include/fields2cover/types/Point.h
@@ -9,6 +9,8 @@
 #define FIELDS2COVER_TYPES_POINT_H_
 
 #include <ogr_geometry.h>
+#include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <functional>
 #include <memory>
@@ -189,7 +191,18 @@ namespace std {
 template<>
 struct hash<f2c::types::Point> {
   inline size_t operator()(const f2c::types::Point& p) const {
-    return size_t(p.getX() + p.getY() * 1e10 + p.getZ() * 1e20);
+    // Quantized to the tolerance of Point::operator==, so that points which
+    // compare equal share a value. Coordinates are hashed, not summed:
+    // the sum overflows to undefined behaviour on negative coordinates.
+    const int64_t coords[3] {
+      std::llround(p.getX() * 1e7),
+      std::llround(p.getY() * 1e7),
+      std::llround(p.getZ() * 1e7)};
+    size_t h {1469598103934665603ULL};
+    for (auto&& c : coords) {
+      h = (h ^ static_cast<size_t>(c)) * 1099511628211ULL;
+    }
+    return h;
   }
 };
 }

--- a/src/fields2cover/route_planning/route_planner_base.cpp
+++ b/src/fields2cover/route_planning/route_planner_base.cpp
@@ -41,11 +41,19 @@ F2CGraph2D RoutePlannerBase::createShortestGraph(
     const F2CCells& cells, const F2CSwathsByCells& swaths_by_cells,
     double d_tol) const {
   F2CGraph2D g;
-  // Add points from swaths that touches border
+  // Connect each swath end to the border of the cell it belongs to. An end
+  // outside every cell is left out: a line to the nearest border would cross
+  // whatever lies between.
+  auto addBorderEdge = [&g, &cells, d_tol] (const F2CPoint& p) {
+    F2CCell cell = cells.getCellWherePoint(p, d_tol);
+    if (!cell.isEmpty()) {
+      g.addEdge(p, cell.closestPointOnBorderTo(p));
+    }
+  };
   for (auto&& swaths : swaths_by_cells) {
     for (auto&& s : swaths) {
-      g.addEdge(s.startPoint(), cells.closestPointOnBorderTo(s.startPoint()));
-      g.addEdge(s.endPoint(),   cells.closestPointOnBorderTo(s.endPoint()));
+      addBorderEdge(s.startPoint());
+      addBorderEdge(s.endPoint());
     }
   }
 
@@ -58,7 +66,8 @@ F2CGraph2D RoutePlannerBase::createShortestGraph(
     }
   }
 
-  // Add start and end point if they exists
+  // Add start and end point if they exists. Unlike a swath end, this point
+  // is allowed to sit outside the field, so it always gets its border edge.
   if (this->r_start_end) {
     g.addEdge(*r_start_end, cells.closestPointOnBorderTo(*r_start_end));
   }

--- a/src/fields2cover/types/Cells.cpp
+++ b/src/fields2cover/types/Cells.cpp
@@ -234,6 +234,15 @@ const Cell Cells::getCellWherePoint(const Point& p) const {
   return Cell();
 }
 
+const Cell Cells::getCellWherePoint(const Point& p, double d_tol) const {
+  for (auto&& cell : *this) {
+    if (p.distance(cell) <= d_tol) {
+      return cell;
+    }
+  }
+  return Cell();
+}
+
 LineString Cells::createLineUntilBorder(
     const f2c::types::Point& p, double ang) const {
   return this->getCellWherePoint(p).createLineUntilBorder(p, ang);

--- a/src/fields2cover/types/Graph.cpp
+++ b/src/fields2cover/types/Graph.cpp
@@ -36,8 +36,30 @@ Graph& Graph::removeEdge(size_t i, size_t j) {
   return this->removeDirectedEdge(i, j).removeDirectedEdge(j, i);
 }
 
+std::unordered_set<size_t> Graph::getNodes() const {
+  std::unordered_set<size_t> nodes;
+  for (const auto& from : this->edges_) {
+    nodes.insert(from.first);
+    for (const auto& to : from.second) {
+      nodes.insert(to.first);
+    }
+  }
+  return nodes;
+}
+
 size_t Graph::numNodes() const {
-  return this->edges_.size();
+  return this->getNodes().size();
+}
+
+size_t Graph::matrixSize() const {
+  size_t size = 0;
+  for (const auto& from : this->edges_) {
+    size = std::max(size, from.first + 1);
+    for (const auto& to : from.second) {
+      size = std::max(size, to.first + 1);
+    }
+  }
+  return size;
 }
 
 size_t Graph::numEdges() const {
@@ -69,7 +91,7 @@ int64_t Graph::getCostFromEdge(size_t from, size_t to, int64_t INF) const {
 
 std::vector<std::vector<size_t>> Graph::allPathsBetween(
     size_t from, size_t to) const {
-  std::vector<bool> visited(this->numNodes(), false);
+  std::vector<bool> visited(this->matrixSize(), false);
   std::vector<std::vector<size_t>> routes(1);
   int route_index = 0;
   this->DFS(from, to, routes, visited, route_index);
@@ -100,7 +122,7 @@ void Graph::DFS(
 }
 
 void  Graph::shortestPathsAndCosts(int64_t INF) {
-  const size_t N = this->numNodes();
+  const size_t N = this->matrixSize();
   this->distance_.assign(N, std::vector<int64_t>(N, INF));
   this->next_.assign(N, std::vector<int64_t>(N, -1));
   initializeMatrices(distance_,next_, INF);
@@ -111,7 +133,7 @@ void Graph::initializeMatrices(std::vector<std::vector<int64_t>>& dist,
     std::vector<std::vector<int64_t>>& next,
     int64_t INF) {
 
-  const size_t N = this->numNodes();
+  const size_t N = this->matrixSize();
 
   // Initialize distances and paths for direct connections
   for (const auto& src : this->edges_) {
@@ -164,7 +186,7 @@ short_path_container_t& Graph::getPaths() {
     this->shortestPathsAndCosts();
   }
   if (shortest_paths_.empty()) {
-    const size_t N = this->numNodes();
+    const size_t N = this->matrixSize();
     shortest_paths_.assign(N, std::vector<std::vector<size_t>>(N));
     for (size_t i = 0; i < N; ++i) {
       for (size_t j = 0; j < N; ++j) {
@@ -184,7 +206,7 @@ short_path_container_t& Graph::getPaths() {
 }
 
 std::vector<size_t> Graph::shortestPath(size_t from, size_t to, int64_t INF) {
-  if (this->numNodes() > 0 && (this->next_.empty() || this->distance_.empty())) {
+  if (!this->edges_.empty() && (this->next_.empty() || this->distance_.empty())) {
     this->shortestPathsAndCosts(INF);
   }
   return this->reconstructPath(from, to, next_);
@@ -206,7 +228,7 @@ std::vector<size_t> Graph::reconstructPath(size_t from,
 }
 
 int64_t Graph::shortestPathCost(size_t from, size_t to, int64_t INF) {
-  if (this->numNodes() > 0 && this->distance_.size() == 0) {
+  if (!this->edges_.empty() && this->distance_.size() == 0) {
     this->shortestPathsAndCosts(INF);
   }
   return this->distance_[from][to];

--- a/src/fields2cover/types/Graph2D.cpp
+++ b/src/fields2cover/types/Graph2D.cpp
@@ -46,6 +46,9 @@ Graph2D& Graph2D::addEdge(
 
 
 Graph2D& Graph2D::removeDirectedEdge(const Point& from, const Point& to) {
+  if (!hasNode(from) || !hasNode(to)) {
+    return *this;
+  }
   this->removeDirectedEdge(nodeToIndex(from), nodeToIndex(to));
   return *this;
 }
@@ -66,6 +69,10 @@ std::vector<Point> Graph2D::getNodes() const {
   return nodes;
 }
 
+bool Graph2D::hasNode(const Point& p) const {
+  return this->nodes_to_index_.count(p) > 0;
+}
+
 size_t Graph2D::nodeToIndex(const Point& p) const {
   return this->nodes_to_index_.at(p);
 }
@@ -76,6 +83,9 @@ Point Graph2D::indexToNode(size_t id) const {
 
 std::vector<std::vector<Point>> Graph2D::allPathsBetween(
     const Point& from, const Point& to) const {
+  if (!hasNode(from) || !hasNode(to)) {
+    return {};
+  }
   auto int_routes = this->allPathsBetween(nodeToIndex(from), nodeToIndex(to));
 
   std::vector<std::vector<Point>> routes;
@@ -90,6 +100,9 @@ std::vector<std::vector<Point>> Graph2D::allPathsBetween(
 
 std::vector<Point> Graph2D::shortestPath(
     const Point& from, const Point& to, int64_t INF) {
+  if (!hasNode(from) || !hasNode(to)) {
+    return {};
+  }
   auto i_path = this->shortestPath(nodeToIndex(from), nodeToIndex(to), INF);
   std::vector<Point> path;
   for (auto&& i : i_path) {
@@ -100,6 +113,9 @@ std::vector<Point> Graph2D::shortestPath(
 
 int64_t Graph2D::shortestPathCost(
     const Point& from, const Point& to, int64_t INF) {
+  if (!hasNode(from) || !hasNode(to)) {
+    return INF;
+  }
   return this->shortestPathCost(nodeToIndex(from), nodeToIndex(to), INF);
 }
 

--- a/tests/cpp/route_planning/route_planner_base_test.cpp
+++ b/tests/cpp/route_planning/route_planner_base_test.cpp
@@ -120,3 +120,25 @@ TEST(fields2cover_rp_route_plan_base, redirect_flag) {
 
 
 
+TEST(fields2cover_rp_route_plan_base, shortestGraphDoesNotLeaveTheCells) {
+  F2CCell cell_a {F2CLinearRing({
+      F2CPoint(0,0), F2CPoint(10,0), F2CPoint(10,10), F2CPoint(0,10), F2CPoint(0,0)})};
+  F2CCell cell_b {F2CLinearRing({
+      F2CPoint(20,0), F2CPoint(30,0), F2CPoint(30,10), F2CPoint(20,10), F2CPoint(20,0)})};
+
+  F2CSwath swath_a {F2CLineString({F2CPoint(2,5), F2CPoint(8,5)}), 1};
+  F2CSwath swath_b {F2CLineString({F2CPoint(22,5), F2CPoint(28,5)}), 1};
+  F2CSwaths swaths;
+  swaths.emplace_back(swath_a);
+  swaths.emplace_back(swath_b);
+  F2CSwathsByCells swaths_by_cells;
+  swaths_by_cells.emplace_back(swaths);
+
+  // Only cell_a is given, so swath_b is outside every cell of the graph.
+  F2CCells cells_a {cell_a};
+  f2c::rp::RoutePlannerBase route_planner;
+  F2CGraph2D g = route_planner.createShortestGraph(cells_a, swaths_by_cells, 1e-4);
+
+  EXPECT_TRUE(g.shortestPath(swath_b.startPoint(), swath_a.startPoint()).empty());
+  EXPECT_FALSE(g.shortestPath(swath_a.startPoint(), swath_a.endPoint()).empty());
+}

--- a/tests/cpp/types/Cells_test.cpp
+++ b/tests/cpp/types/Cells_test.cpp
@@ -145,6 +145,19 @@ TEST(fields2cover_types_cells, WherePoint) {
   EXPECT_EQ(cells.getCellWherePoint(F2CPoint(11, 11)).area(), 6);
 }
 
+TEST(fields2cover_types_cells, getCellWherePointWithTolerance) {
+  F2CCells cells {
+    F2CCell(F2CLinearRing({
+          F2CPoint(0,0), F2CPoint(2,0),F2CPoint(2,2),F2CPoint(0,2), F2CPoint(0,0)
+    }))
+  };
+  F2CPoint just_outside {2 + 1e-9, 1};
+
+  EXPECT_EQ(cells.getCellWherePoint(just_outside).area(), 0);
+  EXPECT_EQ(cells.getCellWherePoint(just_outside, 1e-6).area(), 4);
+  EXPECT_EQ(cells.getCellWherePoint(F2CPoint(5, 5), 1e-6).area(), 0);
+}
+
 TEST(fields2cover_types_cells, setGeometry) {
   F2CLinearRing line {
     F2CPoint(0,0), F2CPoint(2,0), F2CPoint(2,2), F2CPoint(0,2), F2CPoint(0,0)};

--- a/tests/cpp/types/Graph2D_test.cpp
+++ b/tests/cpp/types/Graph2D_test.cpp
@@ -128,3 +128,13 @@ TEST(fields2cover_types_graph2d, shortestPathToPointOutsideGraph) {
   EXPECT_TRUE(g.allPathsBetween(p1, p_out).empty());
   EXPECT_NO_THROW(g.removeEdge(p1, p_out));
 }
+
+TEST(fields2cover_types_graph2d, hasNode) {
+  F2CPoint p1 {0, 0}, p2 {1, 0}, p_out {5, 5};
+  F2CGraph2D g;
+  g.addEdge(p1, p2, 1);
+
+  EXPECT_TRUE(g.hasNode(p1));
+  EXPECT_TRUE(g.hasNode(p2));
+  EXPECT_FALSE(g.hasNode(p_out));
+}

--- a/tests/cpp/types/Graph2D_test.cpp
+++ b/tests/cpp/types/Graph2D_test.cpp
@@ -117,3 +117,14 @@ TEST(fields2cover_types_graph2d, shortestPathOnDirectedEdges) {
   EXPECT_EQ(path.size(), 3);
   EXPECT_EQ(g.shortestPathCost(p1, p3), 2);
 }
+
+TEST(fields2cover_types_graph2d, shortestPathToPointOutsideGraph) {
+  F2CPoint p1 {0, 0}, p2 {1, 0}, p_out {5, 5};
+  F2CGraph2D g;
+  g.addEdge(p1, p2, 1);
+
+  EXPECT_TRUE(g.shortestPath(p1, p_out).empty());
+  EXPECT_EQ(g.shortestPathCost(p1, p_out, 99), 99);
+  EXPECT_TRUE(g.allPathsBetween(p1, p_out).empty());
+  EXPECT_NO_THROW(g.removeEdge(p1, p_out));
+}

--- a/tests/cpp/types/Graph2D_test.cpp
+++ b/tests/cpp/types/Graph2D_test.cpp
@@ -106,3 +106,14 @@ TEST(fields2cover_types_graph2d, shortestPaths) {
 }
 
 
+TEST(fields2cover_types_graph2d, shortestPathOnDirectedEdges) {
+  F2CPoint p1 {0, 0}, p2 {1, 0}, p3 {2, 0};
+  F2CGraph2D g;
+  g.addDirectedEdge(p1, p2, 1);
+  g.addDirectedEdge(p2, p3, 1);
+
+  auto path = g.shortestPath(p1, p3);
+
+  EXPECT_EQ(path.size(), 3);
+  EXPECT_EQ(g.shortestPathCost(p1, p3), 2);
+}

--- a/tests/cpp/types/Graph_test.cpp
+++ b/tests/cpp/types/Graph_test.cpp
@@ -105,3 +105,18 @@ TEST(fields2cover_types_graph, shortestPaths) {
 }
 
 
+TEST(fields2cover_types_graph, numNodesCountsNodesWithoutOutgoingEdges) {
+  f2c::types::Graph g;
+  g.addDirectedEdge(0, 1, 1);
+
+  EXPECT_EQ(g.numNodes(), 2);
+}
+
+TEST(fields2cover_types_graph, shortestPathWithSparseNodeIds) {
+  f2c::types::Graph g;
+  g.addEdge(0, 5, 1);
+  g.addEdge(5, 9, 2);
+
+  EXPECT_EQ(g.shortestPath(0, 9), std::vector<size_t>({0, 5, 9}));
+  EXPECT_EQ(g.shortestPathCost(0, 9), 3);
+}

--- a/tests/cpp/types/Graph_test.cpp
+++ b/tests/cpp/types/Graph_test.cpp
@@ -120,3 +120,12 @@ TEST(fields2cover_types_graph, shortestPathWithSparseNodeIds) {
   EXPECT_EQ(g.shortestPath(0, 9), std::vector<size_t>({0, 5, 9}));
   EXPECT_EQ(g.shortestPathCost(0, 9), 3);
 }
+
+TEST(fields2cover_types_graph, allPathsBetweenWithLargeNodeIds) {
+  f2c::types::Graph g;
+  g.addEdge(0, 100, 1);
+
+  auto paths = g.allPathsBetween(0, 100);
+
+  EXPECT_EQ(paths.size(), 1);
+}

--- a/tests/cpp/types/Point_test.cpp
+++ b/tests/cpp/types/Point_test.cpp
@@ -312,3 +312,10 @@ TEST(fields2cover_types_point, closestPointInSegment) {
 
 }  // namespace f2c
 
+
+TEST(fields2cover_types_point, hashAgreesWithEquality) {
+  F2CPoint a {1, -1}, b {1 + 1e-9, -1 - 1e-9};
+
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(std::hash<F2CPoint>()(a), std::hash<F2CPoint>()(b));
+}


### PR DESCRIPTION
### Motivation

Four independent defects in the shortest-path graph end the same way: a caller gets an
answer it cannot trust, and has no way to tell a real answer from a broken one.

- `Graph` sizes its path matrices by `edges_.size()` but indexes them by the node id, so a
  graph whose ids are sparse — or that has a node reachable only by an incoming edge —
  writes past the end of the matrix. `Graph2D::shortestPath` on a graph built with
  `addDirectedEdge` segfaults in a plain release build.
- `std::hash<Point>` sums the coordinates, which is undefined for negative ones and puts
  points that `operator==` calls equal into different buckets. The graph then throws
  `std::out_of_range` for a node it actually holds.
- `Graph2D` reports a missing node by throwing out of `unordered_map::at`, so every query
  has to be wrapped in `try`/`catch` even though the graph already has a way to say "no
  path": an empty vector, and `INF`.
- `createShortestGraph` connects every swath end to the nearest border point of *any* cell
  it was given. An end that belongs to none of them still gets an edge, and the shortest
  path reaches it by cutting across whatever lies between.

The last one is the reason a caller cannot use the result: the bogus path has two or more
points, so it looks like success.

A comb field, driving from the top of one prong to the top of another, with the graph built
from one prong only. Blue is the field boundary, dark grey the drivable area, green the path
over the full field, red the path the single-prong graph returns.

| before | after |
|---|---|
| ![before](https://github.com/user-attachments/assets/de5a819b-ae63-4e4e-b2b8-2d94dd6f1d7a) | ![after](https://github.com/user-attachments/assets/b153c440-fe98-4a54-af79-7360449f6ac1) |

The red path runs straight across two notches, outside the field, and it is *shorter* than
the green one — which is why the graph prefers it. Afterwards there is no red path: the
query returns empty and the caller can fall back. The green path is identical in both.

The same thing in isolation: two cells with a corridor along the bottom, and a gap that
cannot be driven.

| before | after |
|---|---|
| ![before](https://github.com/user-attachments/assets/badb6365-63dc-44b3-9896-908459f97632) | ![after](https://github.com/user-attachments/assets/1ef18074-ae1f-4220-be35-a0edc03acb13) |

### 1. Size the path matrices by node id (`139f888`)

`numNodes()` returned `edges_.size()`, the number of nodes with an outgoing edge, while
`shortestPathsAndCosts`, `initializeMatrices`, `getPaths` and `allPathsBetween` used it as
the id space. Three lines are enough to corrupt the heap:

```cpp
f2c::types::Graph g;
g.addEdge(0, 5, 1);   // numNodes() == 2, matrices 2x2
g.shortestPath(0, 5); // dist[0][5]
```

`getNodes()` is added — the same method the `v3.0` branch already has, collecting the keys
*and* the targets — and `numNodes()` is defined from it. Matrix sizing moves to a new
`matrixSize()`, the largest id plus one, so `getCosts()` and `getPaths()` keep being indexed
by node id. (`v3.0` solves this by remapping to dense indices, which also removes those two
accessors; the v2 line still exposes them.)

### 2. Hash a Point from its coordinates (`e568abb`)

```cpp
return size_t(p.getX() + p.getY() * 1e10 + p.getZ() * 1e20);
```

Two problems. `size_t(-1e10)` is undefined — the current test suite already triggers it
(`Graph2D_test.cpp:11` uses `{1, -1}`); compile with `-fsanitize=float-cast-overflow` and it
reports. And the resolution is finer than `operator==`'s tolerance, so two points that
compare equal land in different buckets, which is what makes `nodes_to_index_.at()` throw
for a node the graph holds.

The coordinates are now quantized to that tolerance and hashed. Note this does not make
node identity exact: `operator==` is tolerant and therefore not transitive, so no hash can
be fully consistent with it. If tolerant node identity is wanted, it needs a lookup that
knows about `d_tol` rather than a hash.

`std::hash<Point>` has exactly one user in the tree, `Graph2D::nodes_to_index_`.

Measured on the decomposed field of `route_planner_base_test`, before and after:
`nodes=74 edges=338 route_len=568.605551` — unchanged.

### 3. Report a missing node instead of throwing (`a848232`)

`shortestPath`, `shortestPathCost`, `allPathsBetween` and `removeDirectedEdge` looked the
point up with `at()`. They now return an empty path, `INF`, an empty vector, and nothing.

This is not a new convention: `reconstructPath` already returns `{}` when there is no path,
`shortestPathCost` already reads `INF` out of the matrix, and the index form of
`removeDirectedEdge` is already a no-op for an edge that is not there. `hasNode()` is added
so a caller that needs to tell "not a node" from "no path" still can.

### 4. A tolerance for `getCellWherePoint` (`b554a59`)

`touches() || within()` is exact, and a point that decomposition placed a fraction outside
the border it belongs to lands in no cell at all. A `d_tol` overload is added; the existing
one is untouched.

### 5. Connect a swath end only to its own cell (`cc49ab3`)

```cpp
F2CCell cell = cells.getCellWherePoint(p, d_tol);
if (!cell.isEmpty()) {
  g.addEdge(p, cell.closestPointOnBorderTo(p));
}
```

An end outside every cell of the graph gets no edge, so it is not a node, so the query
returns empty rather than a path across the gap.

The route's start/end point deliberately keeps its unconditional edge: unlike a swath end,
it is allowed to sit outside the field, and connecting it to the nearest border is the
point of it.

Note this is only ever reached with an incomplete set of cells. On a full-field `genRoute`
every swath end is inside the cells it was given, and the border point chosen is the same
one as before: for `p` inside cell `A`, any segment from `p` to another cell's border must
cross `∂A`, so `dist(p, ∂A) <= dist(p, ∂B)` always.

### One thing that is not this PR

Building with `-fsanitize=address` makes every test that calls `genRoute` segfault inside
or-tools' `RoutingModel::NextVar`, reached from `computeBestRoute`. It happens on an
unpatched tree as well, a plain `Debug` build without sanitizers is fine, and release is
fine — so it looks like the prebuilt or-tools binary CMake downloads rather than anything in
Fields2Cover. Flagging it only because anyone reproducing this under ASan will run into it.